### PR TITLE
ci: add path-triggered publish workflows for lixsketch and vscode

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,40 @@
+name: Publish @elixpo/lixsketch to NPM
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/lixsketch/**'
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check version is not already published
+        working-directory: packages/lixsketch
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          REMOTE=$(npm view @elixpo/lixsketch version 2>/dev/null || echo "0.0.0")
+          echo "Local version: $LOCAL"
+          echo "Published version: $REMOTE"
+          if [ "$LOCAL" = "$REMOTE" ]; then
+            echo "Version $LOCAL already published. Bump the version first."
+            exit 1
+          fi
+
+      - name: Publish to NPM
+        run: npm publish -w packages/lixsketch --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_LIXSKETCH_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,32 @@
+name: Publish VS Code Extension to Marketplace
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/vscode/**'
+
+jobs:
+  publish:
+    name: Publish to VS Code Marketplace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        working-directory: packages/vscode
+        run: npm run build
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/vscode
+        run: npx @vscode/vsce publish --no-dependencies
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_LIXSKETCH_EXT_PUBLISH_TOKEN }}


### PR DESCRIPTION
Adds two path-triggered CI workflows for automatic publishing.

**publish-npm.yml**
Watches `packages/lixsketch/**` for changes on `main` and publishes
`@elixpo/lixsketch` to NPM. Requires `NPM_LIXSKETCH_PUBLISH_TOKEN` 
to be set in repository secrets.

**publish-vscode.yml**
Watches `packages/vscode/**` for changes on `main`, runs `npm run build` 
first, then publishes to VS Code Marketplace. Requires 
`VSCODE_LIXSKETCH_EXT_PUBLISH_TOKEN` to be set in repository secrets.

Both workflows only trigger on `main` branch — feature branches won't 
accidentally publish anything.

Resolves #5