### PR TITLE
(feat) Implement shortcut and help modal for the docs attached inside the canvas

### DIFF
--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -5,6 +5,7 @@ import useUIStore from '@/store/useUIStore'
 import useSketchStore from '@/store/useSketchStore'
 import useAuthStore from '@/store/useAuthStore'
 import { triggerCloudSync } from '@/hooks/useAutoSave'
+import { triggerDocCloudSync, persistLayoutMode } from '@/hooks/useDocAutoSave'
 import { useTranslation } from '@/hooks/useTranslation'
 
 const CANVAS_BACKGROUNDS = [
@@ -60,6 +61,14 @@ export default function AppMenu() {
   const toggleToolLock = useSketchStore((s) => s.toggleToolLock)
   const toggleSnapToObjects = useSketchStore((s) => s.toggleSnapToObjects)
 
+  const layoutMode = useSketchStore((s) => s.layoutMode)
+  const setLayoutMode = useSketchStore((s) => s.setLayoutMode)
+  const handleSetLayout = (mode) => {
+    if (mode === layoutMode) return
+    setLayoutMode(mode)
+    persistLayoutMode(mode)
+  }
+
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const authUser = useAuthStore((s) => s.user)
   const login = useAuthStore((s) => s.login)
@@ -91,7 +100,7 @@ export default function AppMenu() {
         />
       )}
       <div
-        className={`absolute top-14 right-4 w-[220px] max-h-[calc(100vh-70px)] overflow-y-auto no-scrollbar bg-surface/75 backdrop-blur-lg rounded-2xl z-[1000] border border-border-light p-2 font-[lixFont] transition-all duration-200 ${
+        className={`absolute top-14 right-4 w-[230px] max-h-[calc(100vh-140px)] overflow-y-auto no-scrollbar bg-surface/75 backdrop-blur-lg rounded-2xl z-[1000] border border-border-light p-1.5 font-[lixFont] text-[13px] transition-all duration-200 ${
           menuOpen
             ? 'opacity-100 blur-0 pointer-events-auto'
             : 'opacity-0 blur-[20px] pointer-events-none'
@@ -100,7 +109,7 @@ export default function AppMenu() {
         {/* Open */}
         <button
           onClick={handleOpen}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-folder-open text-sm" />
@@ -124,7 +133,7 @@ export default function AppMenu() {
             }
             closeMenu()
           }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-check-circle text-sm" />
@@ -136,7 +145,7 @@ export default function AppMenu() {
         {/* Save & Share */}
         <button
           onClick={() => { toggleSaveModal(); closeMenu() }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-save text-sm" />
@@ -148,7 +157,7 @@ export default function AppMenu() {
         {/* Export Image */}
         <button
           onClick={() => { toggleExportImageModal(); closeMenu() }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-image text-sm" />
@@ -157,7 +166,7 @@ export default function AppMenu() {
           <span className="text-text-dim text-xs">Ctrl+Shift+E</span>
         </button>
 
-        <hr className="border-border-light my-1.5" />
+        <hr className="border-border-light my-1" />
 
         {/* Commands - highlighted */}
         <button
@@ -174,7 +183,7 @@ export default function AppMenu() {
         {/* Find Text */}
         <button
           onClick={() => { useUIStore.getState().toggleFindBar(); closeMenu() }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-search text-sm" />
@@ -186,7 +195,7 @@ export default function AppMenu() {
         {/* Canvas Properties */}
         <button
           onClick={() => { useUIStore.getState().toggleCanvasProperties(); closeMenu() }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-info-circle text-sm" />
@@ -197,7 +206,7 @@ export default function AppMenu() {
         {/* Help */}
         <button
           onClick={() => { toggleHelpModal(); closeMenu() }}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-help-circle text-sm" />
@@ -205,12 +214,62 @@ export default function AppMenu() {
           </span>
         </button>
 
-        <hr className="border-border-light my-1.5" />
+        <hr className="border-border-light my-1" />
+
+        {/* Document layout */}
+        <div className="px-3 py-1.5">
+          <p className="text-text-dim text-[10px] uppercase tracking-wider mb-1.5 flex items-center gap-1.5">
+            <i className="bx bx-file-blank text-[11px]" />
+            Document
+          </p>
+          <div className="flex items-center gap-1 bg-surface/60 border border-border-light rounded-lg p-0.5">
+            {[
+              { key: 'canvas', icon: 'bx-pen', label: 'Canvas' },
+              { key: 'split', icon: 'bx-layout', label: 'Split' },
+              { key: 'docs', icon: 'bxs-notepad', label: 'Docs' },
+            ].map((m) => {
+              const active = layoutMode === m.key
+              return (
+                <button
+                  key={m.key}
+                  onClick={() => handleSetLayout(m.key)}
+                  title={m.label}
+                  className={`flex-1 flex items-center justify-center gap-1 h-6 rounded-md text-[10.5px] transition-all duration-150 ${
+                    active
+                      ? 'bg-accent-blue text-text-primary'
+                      : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
+                  }`}
+                >
+                  <i className={`bx ${m.icon} text-[11px]`} />
+                  {m.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Sync doc now (Ctrl+S triggers both, but explicit action is useful from menu) */}
+        <button
+          onClick={() => {
+            triggerCloudSync()
+            triggerDocCloudSync()
+            closeMenu()
+          }}
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
+        >
+          <span className="flex items-center gap-2">
+            <i className="bx bx-cloud-upload text-sm" />
+            Sync canvas + doc
+          </span>
+          <span className="text-text-dim text-xs">Ctrl+S</span>
+        </button>
+
+        <hr className="border-border-light my-1" />
 
         {/* Preferences - inline expandable */}
         <button
           onClick={() => setPrefsOpen((p) => !p)}
-          className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200 ${prefsOpen ? 'bg-surface-hover' : ''}`}
+          className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200 ${prefsOpen ? 'bg-surface-hover' : ''}`}
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-cog text-sm" />
@@ -278,7 +337,7 @@ export default function AppMenu() {
         {/* Grid toggle */}
         <button
           onClick={toggleGrid}
-          className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
         >
           <span className="flex items-center gap-2">
             <i className="bx bx-grid-alt text-sm" />
@@ -304,7 +363,7 @@ export default function AppMenu() {
           </span>
         </button>
 
-        <hr className="border-border-light my-1.5" />
+        <hr className="border-border-light my-1" />
 
         {/* Links */}
         {LINKS.map((link) => {
@@ -315,7 +374,7 @@ export default function AppMenu() {
               href={link.href}
               {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
               onClick={closeMenu}
-              className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-text-secondary text-xs hover:bg-surface-hover cursor-pointer transition-all duration-200"
+              className="w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
             >
               <i className={`bx ${link.icon} text-sm`} />
               {link.label}
@@ -323,7 +382,7 @@ export default function AppMenu() {
           )
         })}
 
-        <hr className="border-border-light my-1.5" />
+        <hr className="border-border-light my-1" />
 
         {/* Sign In / Sign Out */}
         {isAuthenticated ? (
@@ -359,7 +418,7 @@ export default function AppMenu() {
           </button>
         )}
 
-        <hr className="border-border-light my-1.5" />
+        <hr className="border-border-light my-1" />
 
         {/* Theme toggle */}
         <div className="px-3 py-2">

--- a/src/components/modals/CanvasPropertiesModal.jsx
+++ b/src/components/modals/CanvasPropertiesModal.jsx
@@ -211,6 +211,67 @@ export default function CanvasPropertiesModal() {
             )}
           </div>
 
+          {/* Document */}
+          <div className="p-3 rounded-xl border border-border-light bg-surface/50">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-text-dim text-[10px] uppercase tracking-wider">Document</p>
+              <button
+                onClick={() => triggerDocCloudSync()}
+                title="Force sync the doc to cloud"
+                className="text-[10px] text-accent-blue hover:text-accent-blue-hover px-1.5 py-0.5 rounded hover:bg-accent-blue/10 cursor-pointer transition-all duration-200"
+              >
+                Sync now
+              </button>
+            </div>
+
+            {/* Layout mode pill toggle */}
+            <div className="flex items-center gap-1 bg-surface/60 border border-border-light rounded-lg p-0.5 mb-2">
+              {[
+                { key: 'canvas', icon: 'bx-pen', label: 'Canvas' },
+                { key: 'split', icon: 'bx-layout', label: 'Split' },
+                { key: 'docs', icon: 'bxs-notepad', label: 'Docs' },
+              ].map((m) => {
+                const active = layoutMode === m.key
+                return (
+                  <button
+                    key={m.key}
+                    onClick={() => handleSetLayout(m.key)}
+                    className={`flex-1 flex items-center justify-center gap-1 h-6 rounded-md text-[10.5px] transition-all duration-150 ${
+                      active
+                        ? 'bg-accent-blue text-text-primary'
+                        : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
+                    }`}
+                  >
+                    <i className={`bx ${m.icon} text-[11px]`} />
+                    {m.label}
+                  </button>
+                )
+              })}
+            </div>
+
+            <InfoRow label="Blocks" value={stats.docBlockCount || 0} icon="bx-list-ul" color="text-purple-400" />
+            <InfoRow label="Local size" value={stats.docSize || '0 B'} icon="bx-data" />
+            <InfoRow
+              label="Last local save"
+              value={
+                stats.docSavedAt
+                  ? new Date(stats.docSavedAt).toLocaleTimeString()
+                  : '—'
+              }
+              icon="bx-time"
+            />
+            <InfoRow
+              label="Last cloud sync"
+              value={
+                stats.docCloudUpdatedAt
+                  ? new Date(stats.docCloudUpdatedAt).toLocaleString()
+                  : '—'
+              }
+              icon="bx-cloud"
+              color={stats.docCloudUpdatedAt ? 'text-green-400' : 'text-text-muted'}
+            />
+          </div>
+
           {/* Save & Sync Status */}
           <div className="p-3 rounded-xl border border-border-light bg-surface/50">
             <p className="text-text-dim text-[10px] uppercase tracking-wider mb-2">Sync Status</p>

--- a/src/components/modals/CanvasPropertiesModal.jsx
+++ b/src/components/modals/CanvasPropertiesModal.jsx
@@ -2,10 +2,12 @@
 
 import { useState, useEffect } from 'react'
 import useUIStore from '@/store/useUIStore'
+import useSketchStore from '@/store/useSketchStore'
 import useAuthStore from '@/store/useAuthStore'
 import useCollabStore from '@/store/useCollabStore'
 import { useProfileStore } from '@/hooks/useGuestProfile'
 import { getSessionID } from '@/hooks/useSessionID'
+import { triggerDocCloudSync, persistLayoutMode } from '@/hooks/useDocAutoSave'
 
 function formatBytes(bytes) {
   if (!bytes || bytes === 0) return '0 B'
@@ -42,6 +44,14 @@ export default function CanvasPropertiesModal() {
   const adminUserId = useCollabStore((s) => s.adminUserId)
   const ws = useCollabStore((s) => s.ws)
 
+  const layoutMode = useSketchStore((s) => s.layoutMode)
+  const setLayoutMode = useSketchStore((s) => s.setLayoutMode)
+  const handleSetLayout = (mode) => {
+    if (mode === layoutMode) return
+    setLayoutMode(mode)
+    persistLayoutMode(mode)
+  }
+
   // Determine if current user is admin
   const myUserId = isAuthenticated ? authUser?.id : guestProfile?.id
   const isAdmin = myUserId && adminUserId && myUserId === adminUserId
@@ -67,9 +77,32 @@ export default function CanvasPropertiesModal() {
     const zoom = window.currentZoom || 1
     const sessionId = getSessionID() || ''
 
-    // Estimate data size from localStorage
-    const saved = localStorage.getItem('lixsketch-autosave')
-    const dataSize = saved ? new Blob([saved]).size : 0
+    // Estimate canvas data size from localStorage (per-session key, fall
+    // back to the legacy single-key entry).
+    const sceneSavedKey = sessionId ? `lixsketch-autosave-${sessionId}` : 'lixsketch-autosave'
+    const sceneSaved = localStorage.getItem(sceneSavedKey) || localStorage.getItem('lixsketch-autosave')
+    const dataSize = sceneSaved ? new Blob([sceneSaved]).size : 0
+
+    // Doc stats: pulled from the doc-autosave localStorage buffer.
+    const docKey = sessionId ? `lixsketch-doc-autosave-${sessionId}` : 'lixsketch-doc-autosave'
+    const docMetaKey = sessionId ? `lixsketch-doc-autosave-meta-${sessionId}` : 'lixsketch-doc-autosave-meta'
+    const docSaved = localStorage.getItem(docKey)
+    let docBlockCount = 0
+    let docSize = 0
+    let docSavedAt = null
+    if (docSaved) {
+      docSize = new Blob([docSaved]).size
+      try {
+        const parsed = JSON.parse(docSaved)
+        if (Array.isArray(parsed?.blocks)) docBlockCount = parsed.blocks.length
+        if (parsed?.savedAt) docSavedAt = parsed.savedAt
+      } catch {}
+    }
+    let docCloudUpdatedAt = null
+    try {
+      const meta = JSON.parse(localStorage.getItem(docMetaKey) || '{}')
+      docCloudUpdatedAt = meta?.lastSeenUpdatedAt || null
+    } catch {}
 
     // Count shape types
     const typeCounts = {}
@@ -85,6 +118,10 @@ export default function CanvasPropertiesModal() {
       dataSize: formatBytes(dataSize),
       sessionId,
       typeCounts,
+      docBlockCount,
+      docSize: formatBytes(docSize),
+      docSavedAt,
+      docCloudUpdatedAt,
     })
   }, [isOpen])
 

--- a/src/components/modals/HelpModal.jsx
+++ b/src/components/modals/HelpModal.jsx
@@ -24,7 +24,7 @@ const ACTION_SHORTCUTS = [
   { keys: 'Ctrl+G', action: 'Group' },
   { keys: 'Ctrl+Shift+G', action: 'Ungroup' },
   { keys: 'Ctrl+D', action: 'Duplicate' },
-  { keys: 'Ctrl+S', action: 'Quick Save (local + cloud sync)' },
+  { keys: 'Ctrl+S', action: 'Quick Save (canvas + doc)' },
   { keys: 'Ctrl+C', action: 'Copy' },
   { keys: 'Ctrl+V', action: 'Paste' },
   { keys: 'Ctrl+Z', action: 'Undo' },
@@ -43,9 +43,36 @@ const VIEW_SHORTCUTS = [
   { keys: 'Ctrl+/', action: 'Command Palette' },
 ]
 
+// ── Doc editor shortcuts ──────────────────────────────────────────
+// Markdown shortcuts auto-convert when typed at the start of a line.
+const DOC_BLOCK_SHORTCUTS = [
+  { keys: '# Space', action: 'Heading 1' },
+  { keys: '## Space', action: 'Heading 2' },
+  { keys: '### Space', action: 'Heading 3' },
+  { keys: '> Space', action: 'Quote' },
+  { keys: '- Space', action: 'Bulleted list' },
+  { keys: '1. Space', action: 'Numbered list' },
+  { keys: '[] Space', action: 'Checklist' },
+  { keys: '``` Space', action: 'Code block' },
+  { keys: '--- Enter', action: 'Divider' },
+  { keys: '/', action: 'Block menu' },
+]
+
+const DOC_INLINE_SHORTCUTS = [
+  { keys: 'Ctrl+B', action: 'Bold' },
+  { keys: 'Ctrl+I', action: 'Italic' },
+  { keys: 'Ctrl+U', action: 'Underline' },
+  { keys: 'Ctrl+Shift+S', action: 'Strikethrough' },
+  { keys: 'Ctrl+E', action: 'Inline code' },
+  { keys: 'Tab', action: 'Indent block' },
+  { keys: 'Shift+Tab', action: 'Outdent block' },
+  { keys: 'Ctrl+Z', action: 'Undo' },
+  { keys: 'Ctrl+Shift+Z', action: 'Redo' },
+]
+
 const TABS = [
-  { id: 'shortcuts', label: 'Shortcuts' },
-  { id: 'about', label: 'About' },
+  { id: 'canvas', label: 'Canvas', icon: 'bx-pen' },
+  { id: 'docs', label: 'Document', icon: 'bxs-notepad' },
 ]
 
 function ShortcutRow({ keys, action }) {
@@ -80,7 +107,7 @@ function ShortcutSection({ title, shortcuts }) {
 export default function HelpModal() {
   const open = useUIStore((s) => s.helpModalOpen)
   const toggleHelpModal = useUIStore((s) => s.toggleHelpModal)
-  const [activeTab, setActiveTab] = useState('shortcuts')
+  const [activeTab, setActiveTab] = useState('canvas')
 
   if (!open) return null
 
@@ -97,7 +124,7 @@ export default function HelpModal() {
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-3">
-          <h2 className="text-text-primary text-base font-medium">Help</h2>
+          <h2 className="text-text-primary text-base font-medium">Shortcuts</h2>
           <button
             onClick={toggleHelpModal}
             className="w-7 h-7 flex items-center justify-center rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-hover transition-all duration-200"
@@ -112,12 +139,13 @@ export default function HelpModal() {
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`px-3 py-1.5 rounded-lg text-xs transition-all duration-200 ${
+              className={`px-3 py-1.5 rounded-lg text-xs flex items-center gap-1.5 transition-all duration-200 ${
                 activeTab === tab.id
                   ? 'bg-surface-hover text-text-primary'
                   : 'text-text-muted hover:text-text-secondary hover:bg-surface-hover/50'
               }`}
             >
+              <i className={`bx ${tab.icon} text-sm`} />
               {tab.label}
             </button>
           ))}
@@ -127,12 +155,9 @@ export default function HelpModal() {
 
         {/* Content - scrollable */}
         <div className="flex-1 overflow-y-auto no-scrollbar px-6 py-4">
-          {activeTab === 'shortcuts' && (
+          {activeTab === 'canvas' && (
             <div className="grid grid-cols-2 gap-6">
-              {/* Left column - Tools */}
               <ShortcutSection title="Tools" shortcuts={TOOL_SHORTCUTS} />
-
-              {/* Right column - Actions + View */}
               <div className="flex flex-col gap-4">
                 <ShortcutSection title="Actions" shortcuts={ACTION_SHORTCUTS} />
                 <ShortcutSection title="View" shortcuts={VIEW_SHORTCUTS} />
@@ -140,17 +165,10 @@ export default function HelpModal() {
             </div>
           )}
 
-          {activeTab === 'about' && (
-            <div className="flex flex-col gap-4 text-text-secondary text-xs leading-relaxed">
-              <p>
-                <span className="text-text-primary font-medium">LixSketch</span> is an
-                open-source alternative to app.eraser.io, combining an infinite canvas
-                drawing tool with a docs editor.
-              </p>
-              <p>
-                Built with vanilla JS, SVG, RoughJS and Perfect-Freehand for a hand-drawn
-                aesthetic. Fully open source.
-              </p>
+          {activeTab === 'docs' && (
+            <div className="grid grid-cols-2 gap-6">
+              <ShortcutSection title="Block markdown" shortcuts={DOC_BLOCK_SHORTCUTS} />
+              <ShortcutSection title="Formatting" shortcuts={DOC_INLINE_SHORTCUTS} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Changes Made

- `src/components/menu/AppMenu.jsx`: Added layout mode toggle (Canvas / Split / Docs) with `persistLayoutMode` persistence, plus a "Sync canvas + doc" menu action calling both `triggerCloudSync` and `triggerDocCloudSync`. Tightened spacing (py-2→1.5, text-xs→12.5px, width 220→230) to accommodate the new sections.
- `src/components/modals/CanvasPropertiesModal.jsx`: Added a Document info panel showing block count, local size, last local save, and last cloud sync. Added layout mode pill toggle inside the modal. Fixed localStorage key to use session-scoped `lixsketch-autosave-${sessionId}` with legacy fallback. Doc stats are pulled from `lixsketch-doc-autosave-*` keys.
- `src/hooks/useDocAutoSave.js` (imported but truncated): Exports `triggerDocCloudSync` and `persistLayoutMode` for use by the menu and properties modal.

## Checklist
- [x] `./biome.sh ci` clean
- [ ] Tested locally: <how>