### PR TITLE
fix: add workflow_dispatch trigger to elixpo-ci.yml

### DIFF
--- a/.github/workflows/elixpo-ci.yml
+++ b/.github/workflows/elixpo-ci.yml
@@ -14,6 +14,7 @@
 name: Elixpo CI
 
 on:
+  workflow_dispatch:  
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Problem
The workflow had no `workflow_dispatch` trigger, so when testing 
manually, all jobs were skipped → "No jobs were run" error.

## Fix
Added `workflow_dispatch` to the `on:` block in elixpo-ci.yml 
so the workflow can be manually triggered and tested.