### PR TITLE
[PATCH]: UX fixes and mermaid diagram class attachment fix

### DIFF
--- a/packages/lixsketch/src/core/MermaidSequenceRenderer.js
+++ b/packages/lixsketch/src/core/MermaidSequenceRenderer.js
@@ -396,26 +396,13 @@ export function renderSequenceOnCanvas(diagram) {
     const frameX = vcx - frameW / 2;
     const frameY = vcy - frameH / 2;
 
-    const title = diagram.title || 'Sequence Diagram';
-
-    // Create frame
-    let frame;
-    try {
-        frame = new window.Frame(frameX, frameY, frameW, frameH, {
-            stroke: '#888', strokeWidth: 2, fill: 'transparent', opacity: 1,
-            frameName: title,
-        });
-        frame._diagramType = 'sequence';
-        frame._diagramData = diagram;
-
-        window.shapes.push(frame);
-        if (window.pushCreateAction) window.pushCreateAction(frame);
-    } catch (err) {
-        console.error('[SequenceRenderer] Frame creation failed:', err);
-        return false;
-    }
-
-    // Insert SVG content into the canvas
+    // Phase B (issue #24, bug #1): no wrapper frame, no stub. Sequence
+    // diagrams have interlocked geometry (lifelines + messages flowing
+    // top-to-bottom) that can't split cleanly into per-actor / per-message
+    // engine shapes the way a flowchart can, so we keep the rendered SVG
+    // as ONE block — but as a first-class shape (`contains` / `move` /
+    // `selectShape` / `removeSelection`) so it's selectable, draggable,
+    // and picked up by the multi-selection rect like any user-drawn shape.
     const NS = 'http://www.w3.org/2000/svg';
     try {
         const graphGroup = document.createElementNS(NS, 'g');
@@ -435,45 +422,83 @@ export function renderSequenceOnCanvas(diagram) {
             }
         }
 
-        // Copy all child elements (skip defs)
         while (svgEl.childNodes.length > 0) {
             const child = svgEl.childNodes[0];
-            if (child.nodeName === 'defs') {
-                svgEl.removeChild(child);
-                continue;
-            }
+            if (child.nodeName === 'defs') { svgEl.removeChild(child); continue; }
             graphGroup.appendChild(child);
         }
-
         window.svg.appendChild(graphGroup);
 
-        // Wrap as a shape-like object for the frame
         const seqShape = {
-            shapeName: 'sequenceContent',
+            shapeName: 'sequence',                 // first-class shapeName
+            shapeID: `sequence-${Date.now().toString(36)}-${Math.floor(Math.random() * 10000)}`,
             group: graphGroup,
             element: graphGroup,
             x: frameX + framePad,
             y: frameY + framePad,
             width: gWidth,
             height: gHeight,
-            move(dx, dy) {
-                this.x += dx;
-                this.y += dy;
-                this.group.setAttribute('transform', `translate(${this.x}, ${this.y})`);
+            rotation: 0,
+            isSelected: false,
+            _selectionRect: null,
+            _diagramType: 'sequence',
+            _diagramData: diagram,
+
+            // ── Shape API ─────────────────────────────────────────────
+            contains(px, py) {
+                return px >= this.x && px <= this.x + this.width
+                    && py >= this.y && py <= this.y + this.height;
             },
-            updateAttachedArrows() {},
+            move(dx, dy) {
+                this.x += dx; this.y += dy;
+                this.group.setAttribute('transform', `translate(${this.x}, ${this.y})`);
+                this._updateSelectionRect();
+            },
+            selectShape() {
+                this.isSelected = true;
+                if (this._selectionRect) return;
+                const r = document.createElementNS(NS, 'rect');
+                r.setAttribute('fill', 'none');
+                r.setAttribute('stroke', '#9b7bf7');
+                r.setAttribute('stroke-width', '1.5');
+                r.setAttribute('stroke-dasharray', '4 3');
+                r.setAttribute('pointer-events', 'none');
+                window.svg.appendChild(r);
+                this._selectionRect = r;
+                this._updateSelectionRect();
+            },
+            removeSelection() {
+                this.isSelected = false;
+                if (this._selectionRect && this._selectionRect.parentNode) {
+                    this._selectionRect.parentNode.removeChild(this._selectionRect);
+                }
+                this._selectionRect = null;
+            },
+            _updateSelectionRect() {
+                if (!this._selectionRect) return;
+                const pad = 4;
+                this._selectionRect.setAttribute('x', this.x - pad);
+                this._selectionRect.setAttribute('y', this.y - pad);
+                this._selectionRect.setAttribute('width', this.width + pad * 2);
+                this._selectionRect.setAttribute('height', this.height + pad * 2);
+            },
+            updateAttachedArrows() {
+                if (typeof window.updateAttachedArrows === 'function') {
+                    window.updateAttachedArrows(this);
+                }
+            },
         };
 
         window.shapes.push(seqShape);
-        if (frame.addShapeToFrame) frame.addShapeToFrame(seqShape);
+        if (window.pushCreateAction) window.pushCreateAction(seqShape);
+
+        // Auto-select so the user sees something landed.
+        window.currentShape = seqShape;
+        seqShape.selectShape();
     } catch (err) {
         console.error('[SequenceRenderer] SVG insertion failed:', err);
+        return false;
     }
-
-    // Select the frame
-    window.currentShape = frame;
-    if (frame.selectFrame) frame.selectFrame();
-    if (window.__sketchStoreApi) window.__sketchStoreApi.setSelectedShapeSidebar('frame');
 
     return true;
 }

--- a/src/components/canvas/ImageSourcePicker.jsx
+++ b/src/components/canvas/ImageSourcePicker.jsx
@@ -95,21 +95,26 @@ export default function ImageSourcePicker() {
       style={{ left: posX, top: posY }}
     >
       <div className="bg-surface-card border border-border-light rounded-xl p-1.5 shadow-2xl shadow-black/40 flex flex-col gap-1 min-w-[200px]">
+        {/* Issue #24 bug #6: AI image generation gated as coming-soon. */}
         <button
-          onClick={handleGenerateAI}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted hover:text-accent-blue hover:bg-surface-hover transition-all group"
+          type="button"
+          disabled
+          title="AI image generation is coming back soon"
+          className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-dim opacity-60 cursor-not-allowed group"
         >
-          <div className="w-8 h-8 rounded-lg bg-accent-blue/10 flex items-center justify-center group-hover:bg-accent-blue/20 transition-all">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-accent-blue">
+          <div className="w-8 h-8 rounded-lg bg-accent-blue/10 flex items-center justify-center">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-accent-blue/60">
               <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
               <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
             </svg>
           </div>
           <div className="flex-1 text-left">
-            <div className="text-sm font-medium">Generate with AI</div>
-            <div className="text-[10px] text-text-dim">10 generations &middot; 5 edits free</div>
+            <div className="text-sm font-medium flex items-center gap-1.5">
+              Generate with AI
+              <span className="text-[8px] uppercase tracking-wider px-1 py-px rounded bg-yellow-500/15 text-yellow-300/90 border border-yellow-500/25 leading-none">Soon</span>
+            </div>
+            <div className="text-[10px] text-text-dim">Reopens when the assistant is back online</div>
           </div>
-          <kbd className="text-[10px] text-text-dim bg-surface-dark px-1.5 py-0.5 rounded">G</kbd>
         </button>
 
         <div className="h-px bg-white/[0.06] mx-2" />

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -274,14 +274,17 @@ export default function Header() {
       <div className="flex items-center gap-2">
         {/* Save status dot */}
         <SaveStatusDot />
-        {/* E2E Shield badge */}
-        <div
-          className="flex items-center gap-1 px-2 py-1 rounded-md bg-green-500/10 text-green-400/80 cursor-default select-none"
-          title="End-to-end encrypted — your data never leaves your device unencrypted"
+        {/* E2E Shield badge — links out to the blog post (issue #24, bug #13). */}
+        <a
+          href="/docs/blog/e2e-encryption"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 px-2 py-1 rounded-md bg-green-500/10 text-green-400/80 hover:bg-green-500/15 hover:text-green-400 transition-colors select-none"
+          title="End-to-end encrypted — click to read how it works"
         >
           <i className="bx bxs-shield text-sm" />
           <span className="text-[10px] font-medium">E2E</span>
-        </div>
+        </a>
 
         {/* Help icon */}
         <button

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -75,6 +75,10 @@ export default function AppMenu() {
   const logout = useAuthStore((s) => s.logout)
 
   const [prefsOpen, setPrefsOpen] = useState(false)
+// Side-flyout for sub-menus (issue #24 bug #11). Mutually exclusive — only
+// one flyout open at a time. Both panels float to the LEFT of the main
+// menu since the menu itself is pinned to the top-right of the viewport.
+const [docOpen, setDocOpen] = useState(false)
 
   // Menu is always accessible (via floating button in view/zen mode)
 
@@ -266,73 +270,77 @@ export default function AppMenu() {
 
         <hr className="border-border-light my-1" />
 
-        {/* Preferences - inline expandable */}
-        <button
-          onClick={() => setPrefsOpen((p) => !p)}
-          className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200 ${prefsOpen ? 'bg-surface-hover' : ''}`}
-        >
-          <span className="flex items-center gap-2">
-            <i className="bx bx-cog text-sm" />
-            {t('menu.preferences')}
-          </span>
-          <i className={`bx bx-chevron-down text-sm text-text-dim transition-transform duration-150 ${prefsOpen ? 'rotate-180' : ''}`} />
-        </button>
+        {/* Preferences — side flyout (issue #24, bug #11). */}
+        <div className="relative">
+          <button
+            onClick={() => { setPrefsOpen((p) => !p); setDocOpen(false) }}
+            className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200 ${prefsOpen ? 'bg-surface-hover' : ''}`}
+          >
+            <span className="flex items-center gap-2">
+              <i className="bx bx-cog text-sm" />
+              {t('menu.preferences')}
+            </span>
+            <i className="bx bx-chevron-left text-sm text-text-dim" />
+          </button>
 
-        {prefsOpen && (
-          <div className="ml-2 border-l border-border-light pl-1">
-            {/* Language Switcher */}
-            <div className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[11px] transition-all duration-200">
-              <span className="flex items-center gap-2">
-                {t('prefs.language')}
-              </span>
-              <select 
-                className="bg-surface-hover text-text-primary text-[10px] rounded px-1 outline-none border border-border-light"
-                value={language}
-                onChange={(e) => persistUIPrefs({ language: e.target.value })}
-              >
-                <option value="en">English</option>
-                <option value="bg">Български</option>
-                <option value="de">Deutsch</option>
-              </select>
-            </div>
-            
-            {PREFERENCE_ITEMS.map((item) => {
-              const isActive =
-                (item.id === 'toolLock' && toolLock) ||
-                (item.id === 'snapObjects' && snapToObjects) ||
-                (item.id === 'toggleGrid' && gridEnabled) ||
-                (item.id === 'zenMode' && zenMode) ||
-                (item.id === 'viewMode' && viewMode) ||
-                (item.toggle) // arrow binding, snap midpoints default on
-
-              const handleClick = () => {
-                if (item.id === 'toolLock') toggleToolLock()
-                else if (item.id === 'snapObjects') toggleSnapToObjects()
-                else if (item.id === 'toggleGrid') toggleGrid()
-                else if (item.id === 'zenMode') { toggleZenMode(); closeMenu() }
-                else if (item.id === 'viewMode') { toggleViewMode(); closeMenu() }
-              }
-
-              return (
-                <button
-                  key={item.id}
-                  onClick={handleClick}
-                  className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[11px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
+          {prefsOpen && (
+            <div
+              className="absolute right-full top-0 mr-2 w-[240px] bg-surface/95 backdrop-blur-lg rounded-2xl border border-border-light p-1.5 shadow-2xl shadow-black/40 max-h-[60vh] overflow-y-auto no-scrollbar"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="text-text-dim text-[10px] uppercase tracking-wider px-2 pb-1.5 pt-0.5 flex items-center gap-1.5">
+                <i className="bx bx-cog text-[11px]" />
+                {t('menu.preferences')}
+              </p>
+              <div className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[11px]">
+                <span>{t('prefs.language')}</span>
+                <select
+                  className="bg-surface-hover text-text-primary text-[10px] rounded px-1 outline-none border border-border-light"
+                  value={language}
+                  onChange={(e) => persistUIPrefs({ language: e.target.value })}
                 >
-                  <span className="flex items-center gap-2">
-                    {isActive && (
-                      <i className="bx bx-check text-sm text-accent-blue" />
+                  <option value="en">English</option>
+                  <option value="bg">Български</option>
+                  <option value="de">Deutsch</option>
+                </select>
+              </div>
+
+              {PREFERENCE_ITEMS.map((item) => {
+                const isActive =
+                  (item.id === 'toolLock' && toolLock) ||
+                  (item.id === 'snapObjects' && snapToObjects) ||
+                  (item.id === 'toggleGrid' && gridEnabled) ||
+                  (item.id === 'zenMode' && zenMode) ||
+                  (item.id === 'viewMode' && viewMode) ||
+                  (item.toggle)
+
+                const handleClick = () => {
+                  if (item.id === 'toolLock') toggleToolLock()
+                  else if (item.id === 'snapObjects') toggleSnapToObjects()
+                  else if (item.id === 'toggleGrid') toggleGrid()
+                  else if (item.id === 'zenMode') { toggleZenMode(); closeMenu() }
+                  else if (item.id === 'viewMode') { toggleViewMode(); closeMenu() }
+                }
+
+                return (
+                  <button
+                    key={item.id}
+                    onClick={handleClick}
+                    className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[11px] hover:bg-surface-hover cursor-pointer transition-all duration-200"
+                  >
+                    <span className="flex items-center gap-2">
+                      {isActive && <i className="bx bx-check text-sm text-accent-blue" />}
+                      {item.label}
+                    </span>
+                    {item.shortcut && (
+                      <span className="text-text-dim text-[10px]">{item.shortcut}</span>
                     )}
-                    {item.label}
-                  </span>
-                  {item.shortcut && (
-                    <span className="text-text-dim text-[10px]">{item.shortcut}</span>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
 
         {/* Grid toggle */}
         <button

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -220,36 +220,55 @@ const [docOpen, setDocOpen] = useState(false)
 
         <hr className="border-border-light my-1" />
 
-        {/* Document layout */}
-        <div className="px-3 py-1.5">
-          <p className="text-text-dim text-[10px] uppercase tracking-wider mb-1.5 flex items-center gap-1.5">
-            <i className="bx bx-file-blank text-[11px]" />
-            Document
-          </p>
-          <div className="flex items-center gap-1 bg-surface/60 border border-border-light rounded-lg p-0.5">
-            {[
-              { key: 'canvas', icon: 'bx-pen', label: 'Canvas' },
-              { key: 'split', icon: 'bx-layout', label: 'Split' },
-              { key: 'docs', icon: 'bxs-notepad', label: 'Docs' },
-            ].map((m) => {
-              const active = layoutMode === m.key
-              return (
-                <button
-                  key={m.key}
-                  onClick={() => handleSetLayout(m.key)}
-                  title={m.label}
-                  className={`flex-1 flex items-center justify-center gap-1 h-6 rounded-md text-[10.5px] transition-all duration-150 ${
-                    active
-                      ? 'bg-accent-blue text-text-primary'
-                      : 'text-text-muted hover:text-text-primary hover:bg-surface-hover'
-                  }`}
-                >
-                  <i className={`bx ${m.icon} text-[11px]`} />
-                  {m.label}
-                </button>
-              )
-            })}
-          </div>
+        {/* Document — side flyout (issue #24, bug #11). */}
+        <div className="relative">
+          <button
+            onClick={() => { setDocOpen((d) => !d); setPrefsOpen(false) }}
+            className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-text-secondary text-[12.5px] hover:bg-surface-hover cursor-pointer transition-all duration-200 ${docOpen ? 'bg-surface-hover' : ''}`}
+          >
+            <span className="flex items-center gap-2">
+              <i className="bx bx-file-blank text-sm" />
+              Document
+            </span>
+            <i className="bx bx-chevron-left text-sm text-text-dim" />
+          </button>
+
+          {docOpen && (
+            <div
+              className="absolute right-full top-0 mr-2 w-[240px] bg-surface/95 backdrop-blur-lg rounded-2xl border border-border-light p-1.5 shadow-2xl shadow-black/40"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="text-text-dim text-[10px] uppercase tracking-wider px-2 pb-1.5 pt-0.5 flex items-center gap-1.5">
+                <i className="bx bx-file-blank text-[11px]" />
+                Document layout
+              </p>
+              {[
+                { key: 'canvas', icon: 'bx-pen',     label: 'Canvas', subtext: 'Drawing only' },
+                { key: 'split',  icon: 'bx-layout',  label: 'Split',  subtext: 'Canvas + docs side-by-side' },
+                { key: 'docs',   icon: 'bxs-notepad', label: 'Docs',   subtext: 'Document editor only' },
+              ].map((m) => {
+                const active = layoutMode === m.key
+                return (
+                  <button
+                    key={m.key}
+                    onClick={() => { handleSetLayout(m.key); setDocOpen(false) }}
+                    className={`w-full flex items-start gap-2.5 px-3 py-2 rounded-lg text-left transition-all duration-150 ${
+                      active ? 'bg-accent-blue/15 text-text-primary' : 'text-text-secondary hover:bg-surface-hover'
+                    }`}
+                  >
+                    <i className={`bx ${m.icon} text-base mt-0.5 ${active ? 'text-accent-blue' : 'text-text-muted'}`} />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[12px] flex items-center gap-1.5">
+                        {m.label}
+                        {active && <i className="bx bx-check text-sm text-accent-blue" />}
+                      </div>
+                      <div className="text-text-dim text-[10px]">{m.subtext}</div>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          )}
         </div>
 
         {/* Sync doc now (Ctrl+S triggers both, but explicit action is useful from menu) */}

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -99,8 +99,8 @@ const [docOpen, setDocOpen] = useState(false)
     <>
       {menuOpen && (
         <div
-          className="fixed inset-0 z-[999]"
-          onClick={() => { closeMenu(); setPrefsOpen(false) }}
+          className="fixed inset-0 z-999"
+          onClick={() => { closeMenu(); setPrefsOpen(false); setDocOpen(false) }}
         />
       )}
       <div
@@ -220,7 +220,6 @@ const [docOpen, setDocOpen] = useState(false)
 
         <hr className="border-border-light my-1" />
 
-        {/* Document — side flyout (issue #24, bug #11). */}
         <div className="relative">
           <button
             onClick={() => { setDocOpen((d) => !d); setPrefsOpen(false) }}
@@ -289,7 +288,6 @@ const [docOpen, setDocOpen] = useState(false)
 
         <hr className="border-border-light my-1" />
 
-        {/* Preferences — side flyout (issue #24, bug #11). */}
         <div className="relative">
           <button
             onClick={() => { setPrefsOpen((p) => !p); setDocOpen(false) }}

--- a/src/components/modals/CanvasPropertiesModal.jsx
+++ b/src/components/modals/CanvasPropertiesModal.jsx
@@ -150,7 +150,7 @@ export default function CanvasPropertiesModal() {
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
 
       <div
-        className="relative bg-surface-card border border-border-light rounded-2xl w-[380px] mx-4 max-h-[85vh] overflow-y-auto docs-scroll"
+        className="relative bg-surface-card border border-border-light rounded-2xl w-[640px] max-w-[94vw] mx-4 max-h-[85vh] overflow-y-auto docs-scroll"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/components/modals/SaveModal.jsx
+++ b/src/components/modals/SaveModal.jsx
@@ -214,7 +214,7 @@ export default function SaveModal() {
 
       {/* Modal */}
       <div
-        className="relative bg-surface-card border border-border-light rounded-2xl w-[420px] mx-4 max-h-[90vh] overflow-y-auto docs-scroll"
+        className="relative bg-surface-card border border-border-light rounded-2xl w-[640px] max-w-[94vw] mx-4 max-h-[90vh] overflow-y-auto docs-scroll"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Changes Made

- `packages/lixsketch/src/core/MermaidSequenceRenderer.js` — Removed the wrapper `Frame` for sequence diagrams; the SVG is now pushed as a single first-class shape with a full Shape API (`contains`, `move`, `selectShape`, `removeSelection`, `updateAttachedArrows`, `_updateSelectionRect`) so it's selectable, draggable, and multi-selection aware. Auto-selects on insert.
- `src/components/canvas/ImageSourcePicker.jsx` — Gated "Generate with AI" button as disabled/coming-soon with a "Soon" badge and updated copy, preventing clicks while the assistant is offline.
- `src/components/header/Header.jsx` — E2E shield badge changed from a static `<div>` to an `<a>` linking to `/docs/blog/e2e-encryption`, with hover transition states.
- `src/components/menu/AppMenu.jsx` — Document layout picker moved from an inline segmented control into a left-side flyout sub-menu with subtext descriptions and active checkmarks. Preferences panel also converted from an inline expandable section to a matching left-side flyout. Added `docOpen` state; `docOpen` and `prefsOpen` are mutually exclusive. Backdrop click now closes both flyouts.

## Checklist

- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>

Fixes #24