### PR TITLE
[ELIXPO] Menu flyouts unclip, muted-text contrast bump, wider command palette (#38 phase A)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,8 +12,14 @@
   --color-accent-blue-hover: #6c67f3;
   --color-text-primary: #fff;
   --color-text-secondary: #e8e8ee;
-  --color-text-muted: #a0a0b0;
-  --color-text-dim: #787888;
+  /* Issue #38 bug #3: bumped both muted tokens for readable contrast on
+   * the dark surface. Old dim (#787888) sat at ~4.0:1 vs the menu bg —
+   * below AA for tiny 10–11px labels. New values:
+   *   muted: 6.7:1 → 8.3:1
+   *   dim:   4.0:1 → 6.7:1  (effectively promoted to the old muted slot)
+   */
+  --color-text-muted: #b8b8c8;
+  --color-text-dim: #a0a0b0;
   --color-border: #333;
   --color-border-light: #3a3a50;
   --color-border-accent: #5555a0;

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -104,7 +104,15 @@ const [docOpen, setDocOpen] = useState(false)
         />
       )}
       <div
-        className={`absolute top-14 right-4 w-[230px] max-h-[calc(100vh-140px)] overflow-y-auto no-scrollbar bg-surface/75 backdrop-blur-lg rounded-2xl z-[1000] border border-border-light p-1.5 font-[lixFont] text-[13px] transition-all duration-200 ${
+        className={`absolute top-14 right-4 w-[230px] max-h-[calc(100vh-140px)] no-scrollbar bg-surface/75 backdrop-blur-lg rounded-2xl z-[1000] border border-border-light p-1.5 font-[lixFont] text-[13px] transition-all duration-200 ${
+          // Issue #38 bug #2: per CSS spec, `overflow-y: auto` forces
+          // `overflow-x` to `auto` as well, which clipped the side-
+          // flyouts (`absolute right-full ...`) so the user saw nothing
+          // when they clicked Preferences or Document. Toggle the y-scroll
+          // off while a flyout is open so the flyout can escape the panel;
+          // restore it the moment the flyout closes.
+          (prefsOpen || docOpen) ? 'overflow-visible' : 'overflow-y-auto'
+        } ${
           menuOpen
             ? 'opacity-100 blur-0 pointer-events-auto'
             : 'opacity-0 blur-[20px] pointer-events-none'

--- a/src/components/modals/CommandPalette.jsx
+++ b/src/components/modals/CommandPalette.jsx
@@ -233,7 +233,7 @@ export default function CommandPalette() {
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
 
       <div
-        className="relative bg-surface-card border border-border-light rounded-2xl w-full max-w-[540px] mx-4 overflow-hidden"
+        className="relative bg-surface-card border border-border-light rounded-2xl w-full max-w-[760px] mx-4 overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Search */}


### PR DESCRIPTION
## What this does
Three small UX fixes from issue #38 phase A.
1. The Preferences and Document side-flyouts open again — the menu panel's `overflow-y-auto` was forcing `overflow-x: auto` (CSS spec) and clipping the absolutely-positioned flyouts. They rendered but were invisible, so clicking the trigger looked like a no-op.
2. Bumped the two muted text tokens (`--color-text-muted`, `--color-text-dim`) so the small descriptive labels, kbd shortcut hints, and menu sub-text are readable against the dark surface (the old dim sat at ~4.0:1 contrast vs the menu bg — below AA for 10–11px text).
3. Widened the command palette modal from `max-w-[540px]` to `max-w-[760px]` so entries stop clipping on bigger screens.

## Why
Triggered by issue #38 phase A. Bug #2 was a regression from the #24 phase-A flyout refactor; #3 + #4 are accessibility/UX polish that were called out in the same review.

## Changes
- `src/components/menu/AppMenu.jsx`: outer panel toggles between `overflow-visible` (while either flyout is open) and `overflow-y-auto` (default). Restores menu scrollability when no flyout is up, lets the flyout escape the panel when one is open.
- `src/app/globals.css`: `--color-text-muted` `#a0a0b0` → `#b8b8c8`; `--color-text-dim` `#787888` → `#a0a0b0`. Dim is effectively promoted into the old muted slot; muted gets a fresh higher-contrast value. Both raised above the AA threshold for small text.
- `src/components/modals/CommandPalette.jsx`: `max-w-[540px]` → `max-w-[760px]`.

## Verification
- Local dev server not run; changes are markup + tokens only.

---
Fixes #38