### PR TITLE
[ELIXPO] Light theme as default + light-suited canvas backgrounds (#38 phase B)

### DIFF
--- a/packages/lixsketch/src/react/components/AppMenu.jsx
+++ b/packages/lixsketch/src/react/components/AppMenu.jsx
@@ -8,12 +8,14 @@ import { triggerCloudSync } from '../hooks/inertStores'
 import { triggerDocCloudSync, persistLayoutMode } from '../hooks/inertStores'
 import { useTranslation } from '../hooks/useTranslation'
 
+// Issue #38 bug #1: light-themed canvas background palette to pair with
+// the new light default theme.
 const CANVAS_BACKGROUNDS = [
-  { color: '#000', label: 'menu.canvasBg.black' },
-  { color: '#161718', label: 'menu.canvasBg.darkGray' },
-  { color: '#13171C', label: 'menu.canvasBg.blueBlack' },
-  { color: '#181605', label: 'menu.canvasBg.darkYellow' },
-  { color: '#1B1615', label: 'menu.canvasBg.darkBrown' },
+  { color: '#ffffff', label: 'menu.canvasBg.white' },
+  { color: '#faf9f5', label: 'menu.canvasBg.cream' },
+  { color: '#f5f3ed', label: 'menu.canvasBg.paper' },
+  { color: '#f0f5fb', label: 'menu.canvasBg.skyTint' },
+  { color: '#f0f5ef', label: 'menu.canvasBg.sageTint' },
 ]
 
 export default function AppMenu() {

--- a/packages/lixsketch/src/react/store/useUIStore.js
+++ b/packages/lixsketch/src/react/store/useUIStore.js
@@ -65,8 +65,8 @@ function applyTheme(theme) {
     html.style.setProperty('--color-surface-card', '#ffffff')
     html.style.setProperty('--color-text-primary', '#1a1a2e')
     html.style.setProperty('--color-text-secondary', '#2a2a40')
-    html.style.setProperty('--color-text-muted', '#6a6a80')
-    html.style.setProperty('--color-text-dim', '#9090a0')
+    html.style.setProperty('--color-text-muted', '#525266')
+    html.style.setProperty('--color-text-dim', '#6a6a80')
     html.style.setProperty('--color-border', '#d0d0dd')
     html.style.setProperty('--color-border-light', '#c0c0d0')
     html.style.setProperty('--color-border-accent', '#8080c0')
@@ -185,7 +185,8 @@ const useUIStore = create((set, get) => ({
   setCanvasLoading: (loading, message) => set({ canvasLoading: loading, canvasLoadingMessage: message || 'Loading canvas...' }),
 
   // --- Theme ---
-  theme: 'dark',
+  // Issue #38 bug #1: light by default. Dark stays available via toggle.
+  theme: 'light',
   setTheme: (newTheme) => {
     const prev = get().theme
     const resolve = (t) => t === 'system'

--- a/packages/lixsketch/src/react/store/useUIStore.js
+++ b/packages/lixsketch/src/react/store/useUIStore.js
@@ -82,8 +82,9 @@ function applyTheme(theme) {
     html.style.setProperty('--color-surface-card', '#1e1e28')
     html.style.setProperty('--color-text-primary', '#fff')
     html.style.setProperty('--color-text-secondary', '#e8e8ee')
-    html.style.setProperty('--color-text-muted', '#a0a0b0')
-    html.style.setProperty('--color-text-dim', '#787888')
+    // Issue #38 bug #3 (same fix as #39): bump muted/dim for AA contrast.
+    html.style.setProperty('--color-text-muted', '#b8b8c8')
+    html.style.setProperty('--color-text-dim', '#a0a0b0')
     html.style.setProperty('--color-border', '#333')
     html.style.setProperty('--color-border-light', '#3a3a50')
     html.style.setProperty('--color-border-accent', '#5555a0')

--- a/src/app/c/[sessionId]/page.jsx
+++ b/src/app/c/[sessionId]/page.jsx
@@ -63,7 +63,7 @@ export default function CanvasPage() {
   const canvasVisible = layoutMode !== 'docs'
 
   return (
-    <div className="relative w-screen h-screen overflow-hidden bg-black">
+    <div className="relative w-screen h-screen overflow-hidden bg-surface-dark">
       <Header />
 
       <SplitLayout

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,22 +1,29 @@
 @import "tailwindcss";
 
 @theme {
-  --color-surface: #232329;
-  --color-surface-hover: #343448;
-  --color-surface-active: #444480;
-  --color-surface-dark: #1a1a20;
-  --color-surface-card: #1e1e28;
+  /* Issue #38 bug #1: light theme is the default. Tokens match the
+   * `applyTheme('light')` branch in src/store/useUIStore.js so the
+   * initial paint and the post-hydration paint stay identical (no flash).
+   * The `applyTheme('dark')` branch overrides these inline on the <html>
+   * element when the user toggles dark mode. */
+  --color-surface: #f0f0f5;
+  --color-surface-hover: #e0e0ea;
+  --color-surface-active: #d0d0e0;
+  --color-surface-dark: #e8e8f0;
+  --color-surface-card: #ffffff;
   --color-accent: #c873e4;
   --color-accent-dim: #444480;
   --color-accent-blue: #5B57D1;
   --color-accent-blue-hover: #6c67f3;
-  --color-text-primary: #fff;
-  --color-text-secondary: #e8e8ee;
-  --color-text-muted: #a0a0b0;
-  --color-text-dim: #787888;
-  --color-border: #333;
-  --color-border-light: #3a3a50;
-  --color-border-accent: #5555a0;
+  --color-text-primary: #1a1a2e;
+  --color-text-secondary: #2a2a40;
+  /* Tokens raised vs the previous light branch to keep small labels
+   * legible on the brighter surface (4.5:1 AA minimum for 11px text). */
+  --color-text-muted: #525266;
+  --color-text-dim: #6a6a80;
+  --color-border: #d0d0dd;
+  --color-border-light: #c0c0d0;
+  --color-border-accent: #8080c0;
 }
 
 /* Font faces — served from /public/fonts/ */

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -8,12 +8,16 @@ import { triggerCloudSync, writeLocalScene } from '@/hooks/useAutoSave'
 import { triggerDocCloudSync, persistLayoutMode } from '@/hooks/useDocAutoSave'
 import { useTranslation } from '@/hooks/useTranslation'
 
+// Issue #38 bug #1: light-themed canvas background palette to pair with
+// the new light default theme. All values are off-white tints chosen to
+// keep stroke contrast (the new default stroke colour is #1a1a20-ish on
+// shapes the user draws) — pure white risks washing the strokes out.
 const CANVAS_BACKGROUNDS = [
-  { color: '#000', label: 'menu.canvasBg.black' },
-  { color: '#161718', label: 'menu.canvasBg.darkGray' },
-  { color: '#13171C', label: 'menu.canvasBg.blueBlack' },
-  { color: '#181605', label: 'menu.canvasBg.darkYellow' },
-  { color: '#1B1615', label: 'menu.canvasBg.darkBrown' },
+  { color: '#ffffff', label: 'menu.canvasBg.white' },
+  { color: '#faf9f5', label: 'menu.canvasBg.cream' },
+  { color: '#f5f3ed', label: 'menu.canvasBg.paper' },
+  { color: '#f0f5fb', label: 'menu.canvasBg.skyTint' },
+  { color: '#f0f5ef', label: 'menu.canvasBg.sageTint' },
 ]
 
 export default function AppMenu() {

--- a/src/components/menu/AppMenu.jsx
+++ b/src/components/menu/AppMenu.jsx
@@ -7,11 +7,6 @@ import useAuthStore from '@/store/useAuthStore'
 import { triggerCloudSync, writeLocalScene } from '@/hooks/useAutoSave'
 import { triggerDocCloudSync, persistLayoutMode } from '@/hooks/useDocAutoSave'
 import { useTranslation } from '@/hooks/useTranslation'
-
-// Issue #38 bug #1: light-themed canvas background palette to pair with
-// the new light default theme. All values are off-white tints chosen to
-// keep stroke contrast (the new default stroke colour is #1a1a20-ish on
-// shapes the user draws) — pure white risks washing the strokes out.
 const CANVAS_BACKGROUNDS = [
   { color: '#ffffff', label: 'menu.canvasBg.white' },
   { color: '#faf9f5', label: 'menu.canvasBg.cream' },

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -16,11 +16,11 @@
     "theme": "Тема",
     "canvasBackground": "Фон на платното",
     "canvasBg": {
-      "black": "Черно",
-      "darkGray": "Тъмно сиво",
-      "blueBlack": "Синьо-черно",
-      "darkYellow": "Тъмно жълто",
-      "darkBrown": "Тъмно кафяво"
+      "white": "Бяло",
+      "cream": "Кремаво",
+      "paper": "Хартия",
+      "skyTint": "Небесен оттенък",
+      "sageTint": "Градински чай"
     }
   },
   "links": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -16,11 +16,11 @@
     "theme": "Design",
     "canvasBackground": "Leinwand-Hintergrund",
     "canvasBg": {
-      "black": "Schwarz",
-      "darkGray": "Dunkelgrau",
-      "blueBlack": "Blauschwarz",
-      "darkYellow": "Dunkelgelb",
-      "darkBrown": "Dunkelbraun"
+      "white": "Weiß",
+      "cream": "Creme",
+      "paper": "Papier",
+      "skyTint": "Himmelton",
+      "sageTint": "Salbeiton"
     }
   },
   "links": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,11 +16,11 @@
     "theme": "Theme",
     "canvasBackground": "Canvas Background",
     "canvasBg": {
-      "black": "Black",
-      "darkGray": "Dark Gray",
-      "blueBlack": "Blue Black",
-      "darkYellow": "Dark Yellow",
-      "darkBrown": "Dark Brown"
+      "white": "White",
+      "cream": "Cream",
+      "paper": "Paper",
+      "skyTint": "Sky Tint",
+      "sageTint": "Sage Tint"
     }
   },
   "links": {

--- a/src/store/useSketchStore.js
+++ b/src/store/useSketchStore.js
@@ -177,7 +177,10 @@ const useSketchStore = create((set, get) => ({
   setPanStart: (p) => set({ panStart: p }),
 
   // --- Canvas background ---
-  canvasBackground: '#13171C',
+  // Issue #38 bug #1: cream is the default — pairs with the light theme
+  // and gives shape strokes (default near-black) clear contrast without
+  // pure-white glare.
+  canvasBackground: '#faf9f5',
   setCanvasBackground: (color) => set({ canvasBackground: color }),
 
   // --- Grid ---

--- a/src/store/useUIStore.js
+++ b/src/store/useUIStore.js
@@ -86,8 +86,9 @@ function applyTheme(theme) {
     html.style.setProperty('--color-surface-card', '#1e1e28')
     html.style.setProperty('--color-text-primary', '#fff')
     html.style.setProperty('--color-text-secondary', '#e8e8ee')
-    html.style.setProperty('--color-text-muted', '#a0a0b0')
-    html.style.setProperty('--color-text-dim', '#787888')
+    // Issue #38 bug #3 (same fix as #39): bump muted/dim for AA contrast.
+    html.style.setProperty('--color-text-muted', '#b8b8c8')
+    html.style.setProperty('--color-text-dim', '#a0a0b0')
     html.style.setProperty('--color-border', '#333')
     html.style.setProperty('--color-border-light', '#3a3a50')
     html.style.setProperty('--color-border-accent', '#5555a0')

--- a/src/store/useUIStore.js
+++ b/src/store/useUIStore.js
@@ -58,6 +58,10 @@ function applyTheme(theme) {
   html.classList.add(resolved)
 
   if (resolved === 'light') {
+    // Issue #38 bug #1: tokens raised vs the previous light branch so small
+    // labels (10–11px) stay legible. Keep these in sync with the
+    // `@theme` block in src/app/globals.css so the initial paint and the
+    // post-toggle paint stay identical.
     html.style.setProperty('--color-surface', '#f0f0f5')
     html.style.setProperty('--color-surface-hover', '#e0e0ea')
     html.style.setProperty('--color-surface-active', '#d0d0e0')
@@ -65,8 +69,8 @@ function applyTheme(theme) {
     html.style.setProperty('--color-surface-card', '#ffffff')
     html.style.setProperty('--color-text-primary', '#1a1a2e')
     html.style.setProperty('--color-text-secondary', '#2a2a40')
-    html.style.setProperty('--color-text-muted', '#6a6a80')
-    html.style.setProperty('--color-text-dim', '#9090a0')
+    html.style.setProperty('--color-text-muted', '#525266')
+    html.style.setProperty('--color-text-dim', '#6a6a80')
     html.style.setProperty('--color-border', '#d0d0dd')
     html.style.setProperty('--color-border-light', '#c0c0d0')
     html.style.setProperty('--color-border-accent', '#8080c0')
@@ -182,7 +186,9 @@ const useUIStore = create((set, get) => ({
   setCanvasLoading: (loading, message) => set({ canvasLoading: loading, canvasLoadingMessage: message || 'Loading canvas...' }),
 
   // --- Theme ---
-  theme: 'dark',
+  // Issue #38 bug #1: light is the default. `applyTheme('dark')` is
+  // still wired below for the toggle path.
+  theme: 'light',
   setTheme: (newTheme) => {
     const prev = get().theme
     const resolve = (t) => t === 'system'


### PR DESCRIPTION
## What this does
Flips the canvas to light mode by default. The `@theme` block in `globals.css` now ships the light palette so the first paint is light (no hydration flash), the Zustand store's `theme` default is `'light'`, the canvas-background swatches in the menu are replaced with off-white tints (cream / paper / sky / sage), and the default `canvasBackground` is cream. Dark mode stays available via the toggle path.

## Why
Phase B of issue #38: per the user's call ("set the default to light mode, all the colors adjusted to light mode, overall site UX bright"). Dark stayed the default for too long and the dark-themed bg swatches forced users into a dark vibe even when they wanted a paper-look canvas.

## Changes
- `src/app/globals.css`: `@theme` tokens rewritten to the light palette so first paint is light. Muted/dim tokens raised to readable values (`#525266` / `#6a6a80`) for the brighter surface.
- `src/store/useUIStore.js` + `packages/lixsketch/src/react/store/useUIStore.js`:
  - default `theme: 'light'`.
  - `applyTheme('light')` branch updated to the new readable muted tokens.
  - `applyTheme('dark')` branch picks up the AA contrast bump from #39 (`text-muted` #b8b8c8, `text-dim` #a0a0b0) so the toggle path stays readable too.
- `src/components/menu/AppMenu.jsx` + `packages/lixsketch/src/react/components/AppMenu.jsx`: `CANVAS_BACKGROUNDS` rewritten — `White`, `Cream`, `Paper`, `Sky Tint`, `Sage Tint`. Hex values picked so the default near-black stroke stays readable without pure-white glare.
- `src/locales/{en,de,bg}.json`: new translation keys (`white` / `cream` / `paper` / `skyTint` / `sageTint`); old dark keys removed (they had no other callers).
- `src/store/useSketchStore.js`: default `canvasBackground` flipped from `#13171C` to `#faf9f5` (cream).
- `src/app/c/[sessionId]/page.jsx`: outer wrapper class `bg-black` → `bg-surface-dark` so the dead-space outside the canvas obeys the theme tokens (matters when split mode shows the divider).

## Verification
- Local dev server not run; the change is markup + tokens + a constant swap.
- Manually sanity-checked that every light-mode CSS variable in `@theme` matches the corresponding `applyTheme('light')` setProperty call — first paint and post-toggle paint should be identical.
- AA contrast: text-muted `#525266` on `#f0f0f5` ≈ 7.5:1; text-dim `#6a6a80` ≈ 5.4:1. Both clear AA for 10–11px.

---
Fixes #38