### PR TITLE
[ELIXPO] Toolbar border + light docs block-hover + wider formatting toolbar (#38)

### DIFF
--- a/src/components/docs/docs-theme.css
+++ b/src/components/docs/docs-theme.css
@@ -204,29 +204,44 @@ body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-container {
   width: 100%;
 }
 
-/* Block hover background */
-.lix-sketch-theme .bn-block-outer:hover > .bn-block {
-  background: rgba(52, 52, 72, 0.35);
+/* Block hover background — light by default, dark variant pinned to
+ * the dark theme. Old rule used a hardcoded `rgba(52,52,72,0.35)` which
+ * read as a black smudge on the light canvas. */
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-block-outer:hover > .bn-block {
+  background: rgba(60, 60, 80, 0.06);
+  border-radius: 6px;
+}
+body.canvas-mode.theme-dark .lix-sketch-theme .bn-block-outer:hover > .bn-block {
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 6px;
 }
 
-/* Slash / formatting menus */
-.lix-sketch-theme .mantine-Menu-dropdown,
-.lix-sketch-theme .mantine-Popover-dropdown,
-.lix-sketch-theme .bn-suggestion-menu {
-  background: #1e1e28 !important;
-  color: #ffffff !important;
-  border: 1px solid #3a3a50 !important;
+/* Slash / formatting menus — same theme split. */
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Menu-dropdown,
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Popover-dropdown,
+body.canvas-mode.theme-dark .lix-sketch-theme .bn-suggestion-menu {
+  background: #292932 !important;
+  color: #f0f0f5 !important;
+  border: 1px solid #3e3e52 !important;
+}
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Menu-dropdown,
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Popover-dropdown,
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-suggestion-menu {
+  background: #fbfaf6 !important;
+  color: #38384e !important;
+  border: 1px solid #d6d4ca !important;
 }
 
 /* Mantine dropdowns render in a portal at <body> level — they ignore the
-   editor wrapper's width. Cap the formatting/link toolbars (which are
-   horizontal) tightly, but give the slash suggestion menu room to lay
-   out its multi-line items (icon + title + subtitle + shortcut hint). */
+   editor wrapper's width. Give the formatting/link toolbars room: the
+   old 360px cap was clipping the rightmost buttons (color, link, etc.)
+   to ~95% of their natural width. The suggestion menu gets even more
+   room to lay out its multi-line items (icon + title + subtitle +
+   shortcut hint). */
 .mantine-Popover-dropdown,
 .bn-link-toolbar,
 .bn-formatting-toolbar {
-  max-width: min(360px, 90vw) !important;
+  max-width: min(560px, 96vw) !important;
 }
 
 .bn-suggestion-menu,
@@ -248,14 +263,24 @@ body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-container {
   max-width: 100%;
 }
 
-/* Floating toolbar buttons */
-.lix-sketch-theme .mantine-ActionIcon-root,
-.lix-sketch-theme .mantine-Button-root {
-  color: #e8e8ee;
+/* Floating toolbar buttons — light by default, dark variant under
+ * the dark theme so the buttons stay readable on the right surface. */
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-ActionIcon-root,
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Button-root {
+  color: #38384e;
 }
-.lix-sketch-theme .mantine-ActionIcon-root:hover,
-.lix-sketch-theme .mantine-Button-root:hover {
-  background: #343448;
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-ActionIcon-root:hover,
+body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Button-root:hover {
+  background: #eceae3;
+  color: #1a1a2e;
+}
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-ActionIcon-root,
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Button-root {
+  color: #d8d8e0;
+}
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-ActionIcon-root:hover,
+body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Button-root:hover {
+  background: #35354a;
   color: #ffffff;
 }
 

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -239,7 +239,7 @@ export default function Header() {
   }
 
   return (
-    <header className="fixed top-0 left-0 right-0 h-12 bg-surface-dark border-b border-[#2c2c35] z-[1001] flex items-center justify-between px-3 font-[lixFont]">
+    <header className="fixed top-0 left-0 right-0 h-12 bg-surface-dark border-b border-border-light z-[1001] flex items-center justify-between px-3 font-[lixFont]">
       {/* Centered layout-mode toggle (canvas / split / docs) */}
       <LayoutModeToggle />
       {/* Left side */}

--- a/src/components/toolbar/Toolbar.jsx
+++ b/src/components/toolbar/Toolbar.jsx
@@ -41,7 +41,7 @@ export default function Toolbar() {
 
   return (
     <>
-    <div className={`absolute left-2.5 top-1/2 -translate-y-1/2 w-[46px] rounded-xl bg-surface z-[1000] flex flex-col items-center py-1.5 gap-0.5 font-[lixFont] max-h-[calc(100vh-120px)] overflow-y-auto no-scrollbar`}>
+    <div className={`absolute left-2.5 top-1/2 -translate-y-1/2 w-[46px] rounded-xl bg-surface border border-border-light shadow-sm z-[1000] flex flex-col items-center py-1.5 gap-0.5 font-[lixFont] max-h-[calc(100vh-120px)] overflow-y-auto no-scrollbar`}>
       {/* Tool lock button at the top */}
       {!viewMode && (
         <>


### PR DESCRIPTION
## What this does
Three small visual fixes on the light-mode canvas.
1. The left tool column now has a border + subtle shadow so it reads as a panel instead of vanishing into the canvas surface (both shared `--color-surface`, so without a border the toolbar dissolved into the background).
2. The docs editor's per-block hover background was a hardcoded `rgba(52,52,72,0.35)` dark smudge — replaced with a theme-aware pair (light: `rgba(60,60,80,0.06)`, dark: `rgba(255,255,255,0.05)`).
3. The floating formatting toolbar that appears on text selection was capped at `max-width: min(360px, 90vw)` — too narrow for the full row of buttons, clipping the rightmost ones (~95% width effect). Bumped to `min(560px, 96vw)`.

Also pulled the floating-toolbar buttons, slash menu, and popovers into the same `body.canvas-mode:not(.theme-dark)` / `body.canvas-mode.theme-dark` split so colors flip cleanly between modes.

## Why
User-reported visual regressions on the new soothing light palette: the toolbar had no visible edge against the matching surface, hovering on a doc block showed a dark blob, and the formatting toolbar clipped on text selection.

## Changes
- `src/components/toolbar/Toolbar.jsx`: added `border border-border-light shadow-sm` to the column wrapper.
- `src/components/header/Header.jsx`: top header border swapped from hardcoded `border-[#2c2c35]` to `border-border-light` so it adapts to both themes.
- `src/components/docs/docs-theme.css`:
  - Block hover split into light + dark rules under `body.canvas-mode:not(.theme-dark)` / `body.canvas-mode.theme-dark`.
  - Slash / formatting menus + suggestion menus + floating action buttons reorganized into the same split (light maps to `#fbfaf6` / `#38384e`, dark maps to softened `#292932` / `#f0f0f5`).
  - Formatting / link / popover toolbars `max-width: min(360px, 90vw)` → `min(560px, 96vw)`.

## Verification
- Local dev server not run; CSS + className only.

---
Refs #38