### PR TITLE
[ELIXPO] AI modal + Mermaid + Graph follow the canvas theme, frame fit, footer borders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixsketch",
-  "version": "5.4.29",
+  "version": "5.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixsketch",
-      "version": "5.4.29",
+      "version": "5.4.30",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -15026,7 +15026,7 @@
     },
     "packages/lixsketch": {
       "name": "@elixpo/lixsketch",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
         "boxicons": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixsketch",
-  "version": "5.4.29",
+  "version": "5.4.30",
   "description": "Open-source infinite canvas sketching with a hand-drawn aesthetic and a Notion-like docs editor",
   "author": {
     "name": "Ayushman Bhattacharya",

--- a/packages/lixsketch/src/core/GraphRenderer.js
+++ b/packages/lixsketch/src/core/GraphRenderer.js
@@ -11,6 +11,35 @@ const GRAPH_COLORS = [
     '#1ABC9C', '#E67E22', '#3498DB', '#E91E63', '#00BCD4',
 ];
 
+// Issue #38 follow-up: theme-aware graph chrome. Light mode flips every
+// hardcoded `rgba(255,255,255,X)` token (designed for dark canvas) to a
+// matching `rgba(60,60,80,X)` so the grid, axes, plot border, and tick
+// labels stay readable on the warm off-white canvas. The equation
+// curves themselves keep their colours from GRAPH_COLORS.
+function graphThemeTokens() {
+    const isDark = typeof document !== 'undefined'
+        && document.body
+        && document.body.classList.contains('theme-dark');
+    if (isDark) {
+        return {
+            outerBg:   '#0d1117',
+            plotBg:    '#111822',
+            gridStroke:'rgba(255,255,255,0.06)',
+            axisStroke:'rgba(255,255,255,0.25)',
+            borderStroke:'rgba(255,255,255,0.1)',
+            tickLabel: '#8b949e',
+        };
+    }
+    return {
+        outerBg:   '#fbfaf6',
+        plotBg:    '#ffffff',
+        gridStroke:'rgba(60,60,80,0.08)',
+        axisStroke:'rgba(60,60,80,0.35)',
+        borderStroke:'rgba(60,60,80,0.16)',
+        tickLabel: '#62627a',
+    };
+}
+
 /**
  * Calculate nice tick intervals for a given range.
  */
@@ -51,10 +80,11 @@ export function renderGraphSVG(equations, settings) {
     const toSvgY = (y) => pad.top + ((yMax - y) / yRange) * plotH;
 
     let svg = '';
+    const tk = graphThemeTokens();
 
     // Background
-    svg += `<rect x="0" y="0" width="${width}" height="${height}" fill="#0d1117" rx="8" />`;
-    svg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="#111822" />`;
+    svg += `<rect x="0" y="0" width="${width}" height="${height}" fill="${tk.outerBg}" rx="8" />`;
+    svg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="${tk.plotBg}" />`;
 
     // Grid & ticks
     const xTick = niceInterval(xRange);
@@ -66,11 +96,10 @@ export function renderGraphSVG(equations, settings) {
         const sx = toSvgX(x);
         if (sx < pad.left || sx > pad.left + plotW) continue;
         if (showGrid) {
-            svg += `<line x1="${sx}" y1="${pad.top}" x2="${sx}" y2="${pad.top + plotH}" stroke="rgba(255,255,255,0.06)" stroke-width="0.5" />`;
+            svg += `<line x1="${sx}" y1="${pad.top}" x2="${sx}" y2="${pad.top + plotH}" stroke="${tk.gridStroke}" stroke-width="0.5" />`;
         }
-        // Tick label
         const label = Math.abs(x) < 1e-10 ? '0' : (Number.isInteger(x) ? x : x.toFixed(1));
-        svg += `<text x="${sx}" y="${pad.top + plotH + 16}" text-anchor="middle" fill="#8b949e" font-size="10" font-family="lixCode, monospace">${label}</text>`;
+        svg += `<text x="${sx}" y="${pad.top + plotH + 16}" text-anchor="middle" fill="${tk.tickLabel}" font-size="10" font-family="lixCode, monospace">${label}</text>`;
     }
 
     // Horizontal grid lines + y labels
@@ -79,24 +108,24 @@ export function renderGraphSVG(equations, settings) {
         const sy = toSvgY(y);
         if (sy < pad.top || sy > pad.top + plotH) continue;
         if (showGrid) {
-            svg += `<line x1="${pad.left}" y1="${sy}" x2="${pad.left + plotW}" y2="${sy}" stroke="rgba(255,255,255,0.06)" stroke-width="0.5" />`;
+            svg += `<line x1="${pad.left}" y1="${sy}" x2="${pad.left + plotW}" y2="${sy}" stroke="${tk.gridStroke}" stroke-width="0.5" />`;
         }
         const label = Math.abs(y) < 1e-10 ? '0' : (Number.isInteger(y) ? y : y.toFixed(1));
-        svg += `<text x="${pad.left - 8}" y="${sy + 3}" text-anchor="end" fill="#8b949e" font-size="10" font-family="lixCode, monospace">${label}</text>`;
+        svg += `<text x="${pad.left - 8}" y="${sy + 3}" text-anchor="end" fill="${tk.tickLabel}" font-size="10" font-family="lixCode, monospace">${label}</text>`;
     }
 
     // Axes
     if (xMin <= 0 && xMax >= 0) {
         const ax = toSvgX(0);
-        svg += `<line x1="${ax}" y1="${pad.top}" x2="${ax}" y2="${pad.top + plotH}" stroke="rgba(255,255,255,0.25)" stroke-width="1" />`;
+        svg += `<line x1="${ax}" y1="${pad.top}" x2="${ax}" y2="${pad.top + plotH}" stroke="${tk.axisStroke}" stroke-width="1" />`;
     }
     if (yMin <= 0 && yMax >= 0) {
         const ay = toSvgY(0);
-        svg += `<line x1="${pad.left}" y1="${ay}" x2="${pad.left + plotW}" y2="${ay}" stroke="rgba(255,255,255,0.25)" stroke-width="1" />`;
+        svg += `<line x1="${pad.left}" y1="${ay}" x2="${pad.left + plotW}" y2="${ay}" stroke="${tk.axisStroke}" stroke-width="1" />`;
     }
 
     // Plot border
-    svg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1" />`;
+    svg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="none" stroke="${tk.borderStroke}" stroke-width="1" />`;
 
     // Equations
     const samplesPerPixel = 2;
@@ -194,39 +223,39 @@ export function renderGraphSVG(equations, settings) {
     // Remove the non-clipped curves from svg (we added them above for building)
     // Rebuild cleanly
     let cleanSvg = '';
-    cleanSvg += `<rect x="0" y="0" width="${width}" height="${height}" fill="#0d1117" rx="8" />`;
-    cleanSvg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="#111822" />`;
+    cleanSvg += `<rect x="0" y="0" width="${width}" height="${height}" fill="${tk.outerBg}" rx="8" />`;
+    cleanSvg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="${tk.plotBg}" />`;
 
     // Grid + ticks (re-add)
     for (let x = xStart; x <= xMax; x += xTick) {
         const sx = toSvgX(x);
         if (sx < pad.left || sx > pad.left + plotW) continue;
         if (showGrid) {
-            cleanSvg += `<line x1="${sx}" y1="${pad.top}" x2="${sx}" y2="${pad.top + plotH}" stroke="rgba(255,255,255,0.06)" stroke-width="0.5" />`;
+            cleanSvg += `<line x1="${sx}" y1="${pad.top}" x2="${sx}" y2="${pad.top + plotH}" stroke="${tk.gridStroke}" stroke-width="0.5" />`;
         }
         const label = Math.abs(x) < 1e-10 ? '0' : (Number.isInteger(x) ? x : x.toFixed(1));
-        cleanSvg += `<text x="${sx}" y="${pad.top + plotH + 16}" text-anchor="middle" fill="#8b949e" font-size="10" font-family="lixCode, monospace">${label}</text>`;
+        cleanSvg += `<text x="${sx}" y="${pad.top + plotH + 16}" text-anchor="middle" fill="${tk.tickLabel}" font-size="10" font-family="lixCode, monospace">${label}</text>`;
     }
     for (let y = yStart; y <= yMax; y += yTick) {
         const sy = toSvgY(y);
         if (sy < pad.top || sy > pad.top + plotH) continue;
         if (showGrid) {
-            cleanSvg += `<line x1="${pad.left}" y1="${sy}" x2="${pad.left + plotW}" y2="${sy}" stroke="rgba(255,255,255,0.06)" stroke-width="0.5" />`;
+            cleanSvg += `<line x1="${pad.left}" y1="${sy}" x2="${pad.left + plotW}" y2="${sy}" stroke="${tk.gridStroke}" stroke-width="0.5" />`;
         }
         const label = Math.abs(y) < 1e-10 ? '0' : (Number.isInteger(y) ? y : y.toFixed(1));
-        cleanSvg += `<text x="${pad.left - 8}" y="${sy + 3}" text-anchor="end" fill="#8b949e" font-size="10" font-family="lixCode, monospace">${label}</text>`;
+        cleanSvg += `<text x="${pad.left - 8}" y="${sy + 3}" text-anchor="end" fill="${tk.tickLabel}" font-size="10" font-family="lixCode, monospace">${label}</text>`;
     }
     // Axes
     if (xMin <= 0 && xMax >= 0) {
         const ax = toSvgX(0);
-        cleanSvg += `<line x1="${ax}" y1="${pad.top}" x2="${ax}" y2="${pad.top + plotH}" stroke="rgba(255,255,255,0.25)" stroke-width="1" />`;
+        cleanSvg += `<line x1="${ax}" y1="${pad.top}" x2="${ax}" y2="${pad.top + plotH}" stroke="${tk.axisStroke}" stroke-width="1" />`;
     }
     if (yMin <= 0 && yMax >= 0) {
         const ay = toSvgY(0);
-        cleanSvg += `<line x1="${pad.left}" y1="${ay}" x2="${pad.left + plotW}" y2="${ay}" stroke="rgba(255,255,255,0.25)" stroke-width="1" />`;
+        cleanSvg += `<line x1="${pad.left}" y1="${ay}" x2="${pad.left + plotW}" y2="${ay}" stroke="${tk.axisStroke}" stroke-width="1" />`;
     }
     // Plot border
-    cleanSvg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1" />`;
+    cleanSvg += `<rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="none" stroke="${tk.borderStroke}" stroke-width="1" />`;
 
     // Clipped curves
     cleanSvg += `<g clip-path="url(#${clipId})">${curves}</g>`;

--- a/packages/lixsketch/src/core/MermaidFlowchartRenderer.js
+++ b/packages/lixsketch/src/core/MermaidFlowchartRenderer.js
@@ -405,7 +405,11 @@ export function renderFlowchartOnCanvas(diagram) {
     // Created up-front so we can call addShapeToFrame as each child is
     // built. _diagramType marks it so Frame.destroy() takes the children
     // along on delete (issue #34 bug #3).
-    const PADDING = 40;
+    //
+    // PADDING bumped from 40 → 90 so edge labels, rotated diamond nodes,
+    // and arrow heads near the diagram boundary stay inside the frame
+    // instead of getting clipped at the corners.
+    const PADDING = 90;
     const frameTitle = diagram.title || 'Mermaid diagram';
     const frame = new window.Frame(
         vcx - dw / 2 - PADDING,

--- a/packages/lixsketch/src/core/MermaidFlowchartRenderer.js
+++ b/packages/lixsketch/src/core/MermaidFlowchartRenderer.js
@@ -18,7 +18,16 @@ const SIDE_MARGIN = 50;
 const TOP_MARGIN = 40;
 const FONT_FAMILY = 'lixFont, sans-serif';
 
-// Theme colors (dark theme)
+// Issue #38 follow-up: theme-aware stroke / fill. Resolved at draw time
+// so a single render call uses whichever palette is active.
+function isThemeDark() {
+    if (typeof document === 'undefined') return true;
+    return !!(document.body && document.body.classList.contains('theme-dark'));
+}
+function nodeStrokeColor() { return isThemeDark() ? '#fff' : '#1a1a2e'; }
+function edgeStrokeColor() { return isThemeDark() ? '#888' : '#444'; }
+
+// Theme colors (dark theme — used by the SVG-string preview path only)
 const THEME = {
     bg: '#1e1e28',
     nodeBg: 'transparent',
@@ -440,12 +449,13 @@ export function renderFlowchartOnCanvas(diagram) {
         const cy = ny + nh / 2;
 
         const opts = {
-            stroke: n.stroke || '#fff',
+            stroke: n.stroke || nodeStrokeColor(),
             strokeWidth: n.strokeWidth ?? 1.5,
             fill: n.fill || 'transparent',
             fillStyle: n.fill && n.fill !== 'transparent' ? 'solid' : 'none',
             roughness: 1,
             label: n.label || '',
+            labelColor: n.labelColor || nodeStrokeColor(),
         };
 
         let shape = null;
@@ -492,11 +502,12 @@ export function renderFlowchartOnCanvas(diagram) {
         const isDotted = style === 'dotted';
 
         const opts = {
-            stroke: e.stroke || '#fff',
+            stroke: e.stroke || edgeStrokeColor(),
             strokeWidth: isThick ? 3 : 1.5,
             roughness: 1,
             strokeDasharray: isDotted ? '5 3' : '',
             label: e.label || '',
+            labelColor: e.labelColor || edgeStrokeColor(),
         };
 
         let connector = null;

--- a/packages/lixsketch/src/core/MermaidSequenceRenderer.js
+++ b/packages/lixsketch/src/core/MermaidSequenceRenderer.js
@@ -449,7 +449,10 @@ export function renderSequenceOnCanvas(diagram) {
         console.error('[SequenceRenderer] window.Frame missing — cannot wrap diagram');
         return false;
     }
-    const PADDING = 24;
+    // Padding bumped 24 → 60 so participant labels + message text near
+    // the frame's edges stay inside on the new wider light canvas.
+    const PADDING = 60;
+    const TK = themeColors();
     const frameTitle = diagram.title || 'Sequence diagram';
     const frame = new window.Frame(
         ox - PADDING,
@@ -457,7 +460,7 @@ export function renderSequenceOnCanvas(diagram) {
         totalWidth + PADDING * 2,
         totalHeight + PADDING * 2,
         {
-            stroke: '#888',
+            stroke: TK.blockBorder,
             strokeWidth: 1,
             fill: 'transparent',
             opacity: 0.7,
@@ -481,12 +484,13 @@ export function renderSequenceOnCanvas(diagram) {
         try {
             // Top participant box
             const topBox = new window.Rectangle(bx, TOP_MARGIN + oy, PARTICIPANT_W, PARTICIPANT_H, {
-                stroke: THEME.participantBorder,
+                stroke: TK.participantBorder,
                 strokeWidth: 1.5,
-                fill: THEME.participantBg,
+                fill: TK.participantBg,
                 fillStyle: 'solid',
                 roughness: 1,
                 label: p.name,
+                labelColor: TK.participantText,
             });
             window.shapes.push(topBox);
             if (window.pushCreateAction) window.pushCreateAction(topBox);
@@ -498,7 +502,7 @@ export function renderSequenceOnCanvas(diagram) {
                 { x: cx, y: topBoxBottom + oy },
                 { x: cx, y: bottomBoxTop + oy },
                 {
-                    stroke: THEME.lifeline,
+                    stroke: TK.lifeline,
                     strokeWidth: 1,
                     strokeDasharray: '6 4',
                     roughness: 0,
@@ -511,12 +515,13 @@ export function renderSequenceOnCanvas(diagram) {
 
             // Bottom participant box (mirrors top — Mermaid convention)
             const bottomBox = new window.Rectangle(bx, bottomBoxTop + oy, PARTICIPANT_W, PARTICIPANT_H, {
-                stroke: THEME.participantBorder,
+                stroke: TK.participantBorder,
                 strokeWidth: 1.5,
-                fill: THEME.participantBg,
+                fill: TK.participantBg,
                 fillStyle: 'solid',
                 roughness: 1,
                 label: p.name,
+                labelColor: TK.participantText,
             });
             window.shapes.push(bottomBox);
             if (window.pushCreateAction) window.pushCreateAction(bottomBox);
@@ -546,11 +551,12 @@ export function renderSequenceOnCanvas(diagram) {
         // line for that, arrow otherwise.
         const isCross = !!m.cross && m.arrowHead === 'cross';
         const opts = {
-            stroke: THEME.messageLine,
+            stroke: TK.messageLine,
             strokeWidth: 1.5,
             roughness: 0,
             strokeDasharray: m.solid ? '' : '6 4',
             label: labelText || '',
+            labelColor: TK.messageText,
         };
 
         try {

--- a/packages/lixsketch/src/core/MermaidSequenceRenderer.js
+++ b/packages/lixsketch/src/core/MermaidSequenceRenderer.js
@@ -26,7 +26,36 @@ const SIDE_MARGIN = 40;
 const FONT_FAMILY = 'lixFont, sans-serif';
 const CODE_FONT = 'lixCode, monospace';
 
-// Theme colors (dark theme matching the app)
+// Issue #38 follow-up: theme-aware palette. The on-canvas renderer reads
+// `themeColors()` at draw time so a single render call gets whichever
+// palette is active. The dark THEME object below is kept for the SVG-
+// string preview path (`renderSequenceSVG`), which is rendered inside
+// the modal's preview pane.
+function themeColors() {
+    const isDark = typeof document !== 'undefined'
+        && document.body
+        && document.body.classList.contains('theme-dark');
+    if (isDark) return THEME;
+    return {
+        bg: '#fbfaf6',
+        participantBg: '#ffffff',
+        participantBorder: '#9c9c9c',
+        participantText: '#38384e',
+        lifeline: '#b0b0b8',
+        messageLine: '#62627a',
+        messageDash: '#888',
+        messageText: '#38384e',
+        noteBg: '#fffce0',
+        noteBorder: '#c0b870',
+        noteText: '#5e5230',
+        blockBg: 'rgba(80,80,120,0.08)',
+        blockBorder: '#9c9c9c',
+        blockLabel: '#62627a',
+        crossColor: '#c2483a',
+    };
+}
+
+// Theme colors (dark theme — preview/SVG-string path).
 const THEME = {
     bg: '#1e1e28',
     participantBg: '#232329',

--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -36,7 +36,7 @@ export default function Footer() {
   return (
     <div className="absolute bottom-1 right-5 flex items-center gap-2.5 z-[1000] font-[lixFont]">
       {/* Undo/Redo */}
-      <div className="flex items-center bg-surface rounded-lg overflow-hidden">
+      <div className="flex items-center bg-surface rounded-lg overflow-hidden border border-border-light shadow-sm">
         <button
           onClick={handleUndo}
           title="Undo (Ctrl+Z)"
@@ -55,7 +55,7 @@ export default function Footer() {
       </div>
 
       {/* Zoom controls */}
-      <div className="flex items-center bg-surface rounded-lg overflow-hidden">
+      <div className="flex items-center bg-surface rounded-lg overflow-hidden border border-border-light shadow-sm">
         <button
           onClick={handleZoomOut}
           title="Zoom Out (Ctrl+-)"

--- a/src/components/modals/AIModal.jsx
+++ b/src/components/modals/AIModal.jsx
@@ -180,7 +180,7 @@ function DiagramPreview({ svgMarkup, className }) {
   return (
     <div
       ref={containerRef}
-      className={`rounded-xl bg-[#111] border border-white/[0.06] overflow-hidden relative select-none ${className || 'w-full h-[clamp(200px,40vh,400px)]'}`}
+      className={`rounded-xl bg-surface-card border border-border-light overflow-hidden relative select-none ${className || 'w-full h-[clamp(200px,40vh,400px)]'}`}
     >
       <div
         style={{


### PR DESCRIPTION
## What this does
Five coordinated theme fixes around the AI/DSL workflow on the new light canvas.
1. AI modal preview pane was a hardcoded `bg-[#111]` slab — swapped to `bg-surface-card` + `border-border-light` so it reads as a light card on the light canvas.
2. Mermaid flowchart on-canvas renderer's stroke defaults (`'#fff'` for both nodes and edges) were invisible on the light canvas — now picked from a theme-aware helper (`#1a1a2e` light / `#fff` dark) at render time.
3. Mermaid flowchart frame padding bumped from 40 → 90 so labels / rotated diamonds / arrow heads near the diagram edge stay inside the frame instead of getting clipped.
4. Mermaid sequence renderer same treatment — themed participant / lifeline / message palette via a new `themeColors()` helper, and frame padding 24 → 60.
5. Graph SVG renderer's hardcoded `rgba(255,255,255,X)` grid / axes / border tokens + the `#0d1117` / `#111822` outer/plot backgrounds + the `#8b949e` tick label colour all flipped to a `graphThemeTokens()` light pair on the light canvas.

Plus the undo/redo and zoom panels in the footer now have `border border-border-light shadow-sm` so they read as distinct controls instead of dissolving into the canvas surface (matches the toolbar treatment from #43).

## Why
User feedback on the new light theme: Mermaid diagrams rendered with white-on-white strokes (invisible), the AI modal preview was still dark, the Graph was dark on a light canvas, and the bottom action panels had no visible edge.

## Changes
- `src/components/modals/AIModal.jsx`: preview wrapper `bg-[#111] border border-white/[0.06]` → `bg-surface-card border border-border-light`.
- `packages/lixsketch/src/core/MermaidFlowchartRenderer.js`:
  - New `isThemeDark()` + `nodeStrokeColor()` / `edgeStrokeColor()` helpers.
  - Node + edge stroke / label defaults use the helpers.
  - `PADDING` 40 → 90 with a comment explaining why.
- `packages/lixsketch/src/core/MermaidSequenceRenderer.js`:
  - New `themeColors()` helper returning the light or dark THEME shape.
  - Participant boxes, lifelines, message arrows, and the wrapper frame's own stroke all source from the helper.
  - Participant + message labels get explicit `labelColor` so they stay readable on the new surface.
  - `PADDING` 24 → 60.
- `packages/lixsketch/src/core/GraphRenderer.js`:
  - New `graphThemeTokens()` helper returning the active palette.
  - All `rgba(255,255,255,X)` grid / axis / border strokes + `#0d1117` / `#111822` backgrounds + `#8b949e` tick labels swap to the helper's tokens in both the initial draw pass and the rebuild-with-clip pass.
- `src/components/footer/Footer.jsx`: undo/redo + zoom-controls + reset-zoom panels gain `border border-border-light shadow-sm`.

## Verification
- Local dev server not run; CSS / token edits only.

---
Refs #38