### PR TITLE
[ELIXPO] Port blogs.elixpo editor block styles to docs panel (light + dark)

### DIFF
--- a/src/components/docs/docs-theme.css
+++ b/src/components/docs/docs-theme.css
@@ -1,198 +1,274 @@
+/* Source Serif 4 — the typeface blogs.elixpo uses for headings + body.
+ * Loaded from Google Fonts since the sketch app doesn't ship it
+ * locally yet. The url is the same display=swap CDN endpoint blogs
+ * uses, so the network cache is shared after one visit. */
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,300..900&display=swap');
+
 /*
- * Reskin BlockNote's dark theme to match sketch.elixpo's palette.
+ * Docs panel theme — ports the blogs.elixpo editor look so the same
+ * block elements (headings, prose, inline code, code blocks, dividers,
+ * lists, menus) render identically inside the sketch.elixpo canvas as
+ * they do on blogs.elixpo.
  *
- * BlockNote exposes a set of CSS custom properties (`--bn-colors-*`)
- * that drive every surface, border, hover state, and accent. We
- * override them under `.lix-sketch-theme` so the editor blends with
- * the canvas chrome instead of using BlockNote's default greys.
- *
- * Token map → sketch globals.css:
- *   --color-surface         #232329  (toolbar / floating panels)
- *   --color-surface-dark    #1a1a20  (page background)
- *   --color-surface-hover   #343448  (hover / selected blocks)
- *   --color-surface-card    #1e1e28  (slash-menu items)
- *   --color-accent-blue     #5B57D1  (selection / focused outline)
- *   --color-text-primary    #ffffff
- *   --color-text-secondary  #e8e8ee
- *   --color-border-light    #3a3a50
+ * Strategy:
+ *   1. Mirror the blogs token set (`--text-primary`, `--bg-app`,
+ *      `--code-bg`, etc.) under `body.canvas-mode` (light default) and
+ *      `body.canvas-mode.theme-dark` (dark override). Values copied
+ *      verbatim from blogs.elixpo/app/globals.css.
+ *   2. Override BlockNote's own `--bn-colors-*` tokens to point at the
+ *      mirrored values so the editor chrome adopts the same palette.
+ *   3. Port the per-block styles from blogs.elixpo/src/styles/editor/
+ *      (base.css + blocks.css) with `.blog-editor-wrapper` rewritten as
+ *      `.lix-sketch-theme` so heading sizes, font, inline-code chip,
+ *      code blocks, and dividers all render the same.
+ *   4. Keep the sketch-specific fixes that aren't part of blogs:
+ *      side-menu vertical stacking, host overflow padding workaround,
+ *      Mantine portal width caps.
  */
 
-/* DARK theme overrides — pinned to `body.canvas-mode.theme-dark` so the
- * dark BlockNote skin only applies when the canvas itself is dark. */
-body.canvas-mode.theme-dark .lix-sketch-theme [data-color-scheme="dark"],
-body.canvas-mode.theme-dark .lix-sketch-theme.bn-container,
-body.canvas-mode.theme-dark .lix-sketch-theme .bn-container,
-body.canvas-mode.theme-dark .lix-sketch-theme [data-color-scheme] {
-  /* Editor surfaces — mapped to the softened dark tokens. */
-  --bn-colors-editor-background: #20202a;
-  --bn-colors-editor-text: #f0f0f5;
-  --bn-colors-menu-background: #25252f;
-  --bn-colors-menu-text: #d8d8e0;
-  --bn-colors-tooltip-background: #292932;
-  --bn-colors-tooltip-text: #f0f0f5;
+/* ── Blogs theme tokens (light default) ─────────────────────────────
+ * Copied from blogs.elixpo/app/globals.css `:root`. Scoped to
+ * `body.canvas-mode` so they only apply inside the canvas page and
+ * don't leak to landing / blog / pricing on the sketch site. */
+body.canvas-mode {
+  --bg-base: #f4f4f6;
+  --bg-app: #ffffff;
+  --bg-surface: #f7f7f9;
+  --bg-elevated: #eeeff2;
+  --bg-hover: rgba(0, 0, 0, 0.04);
+  --bg-active: rgba(0, 0, 0, 0.07);
+  --border-default: #dcdce4;
+  --border-hover: #c8c8d4;
+  --text-primary: #111118;
+  --text-secondary: #2d2d3a;
+  --text-body: #3d3d50;
+  --text-muted: #5c5c72;
+  --text-faint: #8585a0;
+  --accent: #9b7bf7;
+  --accent-hover: #8b6ae6;
+  --accent-subtle: rgba(155, 123, 247, 0.08);
+  --accent-text: #7c5ce7;
+  --selection-bg: rgba(155, 123, 247, 0.15);
+  --selection-text: #111118;
+  --divider: #e8e8ee;
 
-  --bn-colors-hovered-background: #35354a;
-  --bn-colors-hovered-text: #f0f0f5;
-  --bn-colors-selected-background: #5B57D1;
-  --bn-colors-selected-text: #ffffff;
-
-  --bn-colors-disabled-background: #20202a;
-  --bn-colors-disabled-text: #92929e;
-
-  --bn-colors-side-menu: #92929e;
-
-  --bn-colors-border: #3e3e52;
-  --bn-colors-shadow: rgba(0, 0, 0, 0.4);
-
-  --bn-colors-highlights-blue-background: rgba(91, 87, 209, 0.18);
-  --bn-colors-highlights-blue-text: #aeacff;
+  /* Code block tokens — light. Slightly stronger lang chip so it's
+   * visible against the page (blogs has the same comment in their CSS). */
+  --code-bg: #f8f8fb;
+  --code-text: #3d3d50;
+  --code-lang-bg: #dfe3ea;
+  --code-lang-text: #44485a;
 }
 
-/* LIGHT theme overrides — kick in whenever the canvas is in (default)
- * light mode. Without these, BlockNote keeps its hardcoded dark surfaces
- * regardless of the LixThemeProvider value, leaving a black docs panel
- * next to a cream canvas. Tokens map to the same warm off-white the
- * canvas + chrome use. */
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme [data-color-scheme],
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme.bn-container,
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-container {
-  --bn-colors-editor-background: #f4f3ee;
-  --bn-colors-editor-text: #38384e;
-  --bn-colors-menu-background: #fbfaf6;
-  --bn-colors-menu-text: #38384e;
-  --bn-colors-tooltip-background: #fbfaf6;
-  --bn-colors-tooltip-text: #38384e;
+body.canvas-mode.theme-dark {
+  --bg-base: #0c1017;
+  --bg-app: #131922;
+  --bg-surface: #141a26;
+  --bg-elevated: #1c2333;
+  --bg-hover: rgba(255, 255, 255, 0.03);
+  --bg-active: rgba(255, 255, 255, 0.05);
+  --border-default: #232d3f;
+  --border-hover: #2e3b50;
+  --text-primary: #e8edf5;
+  --text-secondary: #b0bdd0;
+  --text-body: #cbd5e1;
+  --text-muted: #7b8da4;
+  --text-faint: #566479;
+  --accent: #9b7bf7;
+  --accent-hover: #b69aff;
+  --accent-subtle: rgba(155, 123, 247, 0.08);
+  --accent-text: #b69aff;
+  --selection-bg: #9b7bf740;
+  --selection-text: #fff;
+  --divider: #232d3f;
 
-  --bn-colors-hovered-background: #eceae3;
-  --bn-colors-hovered-text: #38384e;
-  --bn-colors-selected-background: #5B57D1;
+  --code-bg: #0e1219;
+  --code-text: #c8d1e0;
+  --code-lang-bg: #1a2030;
+  --code-lang-text: #9ba8b9;
+}
+
+/* ── BlockNote token map ────────────────────────────────────────────
+ * Reroute BlockNote's own variables to point at the blogs tokens so
+ * the editor surface adopts the same palette without further rules. */
+.lix-sketch-theme [data-color-scheme="dark"],
+.lix-sketch-theme.bn-container,
+.lix-sketch-theme .bn-container,
+.lix-sketch-theme [data-color-scheme] {
+  --bn-colors-editor-background: var(--bg-app);
+  --bn-colors-editor-text: var(--text-primary);
+  --bn-colors-menu-background: var(--bg-app);
+  --bn-colors-menu-text: var(--text-primary);
+  --bn-colors-tooltip-background: var(--bg-elevated);
+  --bn-colors-tooltip-text: var(--text-primary);
+  --bn-colors-hovered-background: var(--bg-hover);
+  --bn-colors-hovered-text: var(--text-primary);
+  --bn-colors-selected-background: var(--accent);
   --bn-colors-selected-text: #ffffff;
-
-  --bn-colors-disabled-background: #f4f3ee;
-  --bn-colors-disabled-text: #80808f;
-
-  --bn-colors-side-menu: #80808f;
-
-  --bn-colors-border: #d6d4ca;
-  --bn-colors-shadow: rgba(60, 60, 80, 0.12);
-
+  --bn-colors-disabled-background: var(--bg-app);
+  --bn-colors-disabled-text: var(--text-faint);
+  --bn-colors-side-menu: var(--text-faint);
+  --bn-colors-border: var(--border-default);
+  --bn-colors-shadow: rgba(0, 0, 0, 0.1);
   --bn-colors-highlights-blue-background: rgba(91, 87, 209, 0.14);
-  --bn-colors-highlights-blue-text: #5B57D1;
+  --bn-colors-highlights-blue-text: var(--accent-text);
 }
 
-/* The wrapper that BlockNote renders inside our flex column.
-   Use sketch's handwritten lixFont everywhere except code blocks,
-   inline code, and KaTeX math (which need their own typefaces). */
-.lix-sketch-theme .bn-container {
-  background: var(--bn-colors-editor-background);
-  color: var(--bn-colors-editor-text);
-  font-family: 'lixFont', system-ui, sans-serif;
-}
-
-.lix-sketch-theme .bn-editor,
-.lix-sketch-theme .bn-block-content,
-.lix-sketch-theme [contenteditable="true"] {
-  font-family: 'lixFont', system-ui, sans-serif;
-}
-
-/* Code, inline code, and math keep the package defaults. */
-.lix-sketch-theme pre,
-.lix-sketch-theme code,
-.lix-sketch-theme .bn-code-block,
-.lix-sketch-theme .bn-inline-content code,
-.lix-sketch-theme .shiki,
-.lix-sketch-theme .katex,
-.lix-sketch-theme .katex * {
-  font-family: revert !important;
-}
-
-/* Inline code — give it a clearly visible chip so it's distinguishable
-   from prose. The package ships its own inline-code rule but it's
-   wrapped in dark/light vars that may not be set in this consumer. */
-.lix-sketch-theme .bn-inline-content code,
-.lix-sketch-theme p code,
-.lix-sketch-theme li code,
-.lix-sketch-theme h1 code,
-.lix-sketch-theme h2 code,
-.lix-sketch-theme h3 code,
-.lix-sketch-theme h4 code,
-.lix-sketch-theme h5 code {
-  background: rgba(196, 181, 253, 0.18) !important;
-  color: #d8c7ff !important;
-  border: 1px solid rgba(196, 181, 253, 0.28);
-  border-radius: 5px;
-  padding: 0.12em 0.45em;
-  font-size: 0.88em;
-}
-
-/* Code blocks — explicit dark surface with a visible boundary so they
-   read as a distinct block in the editor. Keeps Shiki tokens intact. */
-.lix-sketch-theme [data-content-type="codeBlock"] {
-  background: #0d1019 !important;
-  border: 1px solid #2a2f3e !important;
-  border-radius: 8px !important;
-  padding: 12px 14px !important;
-  margin: 8px 0 !important;
-}
-.lix-sketch-theme [data-content-type="codeBlock"] code,
-.lix-sketch-theme [data-content-type="codeBlock"] pre,
-.lix-sketch-theme [data-content-type="codeBlock"] .shiki,
-.lix-sketch-theme [data-content-type="codeBlock"] .shiki * {
-  background: transparent !important;
-  color: #d8d8e8;
-  /* Bump up from the package's 0.9em — too small to read comfortably
-     in the split-pane editor. */
-  font-size: 14px !important;
-  line-height: 1.6 !important;
-}
-
-/* The editable surface itself */
+/* ── Editor surface ────────────────────────────────────────────────
+ * Verbatim from blogs base.css with `.blog-editor-wrapper` →
+ * `.lix-sketch-theme`. */
 .lix-sketch-theme .bn-editor {
   background: transparent;
-  color: var(--bn-colors-editor-text);
-  caret-color: var(--bn-colors-selected-background);
+  color: var(--text-primary);
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: 1em;
+  line-height: 1.75;
+  padding-left: 0;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+  caret-color: var(--accent);
 }
 
-/* The host has overflow-y: auto which forces overflow-x to clip too.
-   BlockNote's side menu is positioned by Floating UI in JS at
-   `left = block.left - menu.width`, putting it in the block's
-   negative-x space — clipped by the host. Two-part fix:
-     (1) increase wrapper padding-left so block.left starts further
-         right, giving Floating UI room.
-     (2) constrain the side-menu container width via CSS so its
-         computed left edge stays inside the host. */
-.lix-sketch-theme .lix-editor-wrapper {
-  padding-left: 3.5rem;     /* > default side-menu width (~40px) */
-  padding-right: 1.5rem;
+.lix-sketch-theme .bn-container {
+  background: transparent;
+  border: none;
+  padding: 0;
 }
 
-/* Stack the +/drag-handle vertically. Two things to fix vs the
-   package's own bn-side-menu rule:
-     1. The package sets `height: 28px; overflow: hidden` — built for a
-        single horizontal row. That clips the drag-handle when stacked
-        vertically. We unwind those caps.
-     2. Don't force fixed width/height on children — the drag-handle is
-        wrapped in a Mantine Menu.Root <div>, and collapsing it hides
-        the inner button. */
-.lix-sketch-theme .bn-side-menu {
-  display: flex !important;
-  flex-direction: column !important;
-  gap: 2px !important;
-  align-items: center;
-  height: auto !important;
-  max-height: none !important;
-  min-height: 0 !important;
-  overflow: visible !important;
-  padding: 2px 0 !important;
+.lix-sketch-theme [class*="blockOuter"] {
+  padding-left: 0;
 }
 
-/* Horizontal-rule (`---` markdown shortcut) — the package styles the
-   <hr> with `background: var(--border-default)` but never defines that
-   variable, so the line collapses to invisible and only the surrounding
-   margin/padding shows (looks like a big empty block). Force a color
-   here. Tighten the surrounding spacing too. */
+.lix-sketch-theme .bn-block-content {
+  font-size: 1em;
+}
+
+/* Placeholder */
+.lix-sketch-theme .bn-inline-content[data-placeholder]::before {
+  color: var(--text-faint);
+  font-style: normal;
+}
+
+/* ── Headings — Source Serif 4, blogs sizes ─────────────────────── */
+.lix-sketch-theme .bn-default-styles h1 {
+  font-size: 30px !important;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-weight: 700 !important;
+  color: var(--text-primary);
+}
+.lix-sketch-theme .bn-default-styles h2 {
+  font-size: 24px !important;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-weight: 650 !important;
+  color: var(--text-primary);
+}
+.lix-sketch-theme .bn-default-styles h3 {
+  font-size: 20px !important;
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-weight: 600 !important;
+  color: var(--text-primary);
+}
+
+/* ── Inline code — purple accent, theme-aware ──────────────────── */
+.lix-sketch-theme code {
+  color: #7c3aed;
+  background: rgba(124, 58, 237, 0.08);
+  border-radius: 4px;
+  padding: 0.15em 0.4em;
+  font-size: 0.82em;
+  font-family: 'lixCode', monospace;
+  -webkit-hyphens: none;
+  hyphens: none;
+  text-decoration: none !important;
+  -webkit-text-decoration: none !important;
+  -webkit-text-decorations-in-effect: none !important;
+  text-decoration-line: none !important;
+  text-decoration-style: initial !important;
+  text-underline-position: under;
+}
+
+body.canvas-mode.theme-dark .lix-sketch-theme code {
+  color: #c4b5fd;
+  background: rgba(196, 181, 253, 0.1);
+}
+
+/* Force hide spellcheck squiggles on all code elements */
+.lix-sketch-theme code *,
+.lix-sketch-theme [data-content-type="codeBlock"] * {
+  text-decoration: none !important;
+  -webkit-text-decoration: none !important;
+  -webkit-text-decorations-in-effect: none !important;
+  text-decoration-line: none !important;
+}
+
+/* Reset inline-code styles inside code blocks — Shiki/theme handles
+ * those tokens. */
+.lix-sketch-theme [data-content-type="codeBlock"] code {
+  color: var(--code-text);
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-family: inherit;
+  font-size: 0.84em;
+  line-height: 1.7;
+}
+
+/* ── Code blocks ───────────────────────────────────────────────── */
+.lix-sketch-theme [data-content-type="codeBlock"] {
+  background: var(--code-bg);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  font-family: 'lixCode', monospace;
+  padding: 4px 0;
+  margin: 12px 0;
+  overflow-x: auto;
+  outline: none;
+  box-shadow: none;
+  -webkit-hyphens: none;
+  hyphens: none;
+}
+
+.lix-sketch-theme [data-content-type="codeBlock"] [contenteditable] {
+  padding: 8px 16px !important;
+  font-family: 'lixCode', 'SF Mono', 'Fira Code', monospace !important;
+  -webkit-text-decorations-in-effect: none;
+}
+
+.lix-sketch-theme [data-content-type="codeBlock"] [contenteditable] * {
+  text-decoration: none !important;
+}
+
+/* Shiki syntax highlighting — let inline styles drive token color */
+.lix-sketch-theme [data-content-type="codeBlock"] code span[style] {
+  background: none !important;
+}
+
+/* Language selector dropdown */
+.lix-sketch-theme [data-content-type="codeBlock"] select {
+  background: var(--code-lang-bg);
+  color: var(--code-lang-text);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: 'lixCode', monospace;
+  cursor: pointer;
+  outline: none;
+  margin: 4px 8px;
+}
+.lix-sketch-theme [data-content-type="codeBlock"] select:focus {
+  border-color: var(--accent);
+}
+
+/* Suppress the BlockNote selection ring on the custom blocks */
+.lix-sketch-theme .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="codeBlock"]) > .bn-block,
+.lix-sketch-theme .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="blockEquation"]) > .bn-block,
+.lix-sketch-theme .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="mermaidBlock"]) > .bn-block {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+/* ── Divider — uses blogs `--border-default` so it adapts. ──────── */
 .lix-sketch-theme [data-content-type="divider"] {
   margin: 8px 0 !important;
   padding: 4px 0 !important;
@@ -200,44 +276,28 @@ body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-container {
 .lix-sketch-theme [data-content-type="divider"] hr {
   border: none !important;
   height: 1px !important;
-  background: #3a3a50 !important;
+  background: var(--border-default) !important;
   width: 100%;
 }
 
-/* Block hover background — light by default, dark variant pinned to
- * the dark theme. Old rule used a hardcoded `rgba(52,52,72,0.35)` which
- * read as a black smudge on the light canvas. */
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-block-outer:hover > .bn-block {
-  background: rgba(60, 60, 80, 0.06);
-  border-radius: 6px;
-}
-body.canvas-mode.theme-dark .lix-sketch-theme .bn-block-outer:hover > .bn-block {
-  background: rgba(255, 255, 255, 0.05);
+/* ── Block hover ─────────────────────────────────────────────────
+ * Light = subtle dark wash; dark = subtle white wash. */
+.lix-sketch-theme .bn-block-outer:hover > .bn-block {
+  background: var(--bg-hover);
   border-radius: 6px;
 }
 
-/* Slash / formatting menus — same theme split. */
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Menu-dropdown,
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Popover-dropdown,
-body.canvas-mode.theme-dark .lix-sketch-theme .bn-suggestion-menu {
-  background: #292932 !important;
-  color: #f0f0f5 !important;
-  border: 1px solid #3e3e52 !important;
-}
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Menu-dropdown,
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Popover-dropdown,
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-suggestion-menu {
-  background: #fbfaf6 !important;
-  color: #38384e !important;
-  border: 1px solid #d6d4ca !important;
+/* ── Slash / formatting / popover menus ────────────────────────── */
+.lix-sketch-theme .mantine-Menu-dropdown,
+.lix-sketch-theme .mantine-Popover-dropdown,
+.lix-sketch-theme .bn-suggestion-menu {
+  background: var(--bg-elevated) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-default) !important;
 }
 
-/* Mantine dropdowns render in a portal at <body> level — they ignore the
-   editor wrapper's width. Give the formatting/link toolbars room: the
-   old 360px cap was clipping the rightmost buttons (color, link, etc.)
-   to ~95% of their natural width. The suggestion menu gets even more
-   room to lay out its multi-line items (icon + title + subtitle +
-   shortcut hint). */
+/* Portal-rendered toolbars — give them room (the old 360px cap was
+ * clipping the formatting button row at ~95% width). */
 .mantine-Popover-dropdown,
 .bn-link-toolbar,
 .bn-formatting-toolbar {
@@ -252,9 +312,6 @@ body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-suggestion-menu {
   overflow-x: hidden;
 }
 
-/* Slash-menu items keep their native multi-row layout — only clamp the
-   subtitle to a single line so very long descriptions don't break the
-   menu. Title row stays untouched. */
 .bn-suggestion-menu-item .bn-suggestion-menu-item-subtitle,
 .mantine-Menu-item .bn-suggestion-menu-item-subtitle {
   white-space: nowrap;
@@ -263,40 +320,48 @@ body.canvas-mode:not(.theme-dark) .lix-sketch-theme .bn-suggestion-menu {
   max-width: 100%;
 }
 
-/* Floating toolbar buttons — light by default, dark variant under
- * the dark theme so the buttons stay readable on the right surface. */
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-ActionIcon-root,
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Button-root {
-  color: #38384e;
+/* Floating-toolbar action buttons — text adapts to theme via vars */
+.lix-sketch-theme .mantine-ActionIcon-root,
+.lix-sketch-theme .mantine-Button-root {
+  color: var(--text-primary);
 }
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-ActionIcon-root:hover,
-body.canvas-mode:not(.theme-dark) .lix-sketch-theme .mantine-Button-root:hover {
-  background: #eceae3;
-  color: #1a1a2e;
-}
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-ActionIcon-root,
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Button-root {
-  color: #d8d8e0;
-}
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-ActionIcon-root:hover,
-body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Button-root:hover {
-  background: #35354a;
-  color: #ffffff;
+.lix-sketch-theme .mantine-ActionIcon-root:hover,
+.lix-sketch-theme .mantine-Button-root:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
-/* I-beam cursor on the editable surface. Sketch.elixpo's canvas-mode
-   doesn't set a body cursor, but the editor still inherits 'default'
-   from the page — force the text caret so typing feels right. Mirrors
-   the same rule shipped in @elixpo/lixeditor (post-republish this is
-   redundant but harmless). */
+/* ── Sketch-specific layout fixes (kept from prior docs-theme.css) ─
+ * The host container has `overflow-y: auto` which forces overflow-x
+ * to clip too. BlockNote's side menu is positioned via Floating UI in
+ * the block's negative-x space — clipped by the host. Add a bit of
+ * left padding so the menu has room. */
+.lix-sketch-theme .lix-editor-wrapper {
+  padding-left: 3.5rem;
+  padding-right: 1.5rem;
+}
+
+/* Stack the +/drag handle vertically and unwind the package's
+ * single-row caps so the drag-handle isn't clipped. */
+.lix-sketch-theme .bn-side-menu {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 2px !important;
+  align-items: center;
+  height: auto !important;
+  max-height: none !important;
+  min-height: 0 !important;
+  overflow: visible !important;
+  padding: 2px 0 !important;
+}
+
+/* Cursor — text on the editable area, pointer on chrome. */
 .lix-sketch-theme,
 .lix-sketch-theme .bn-container,
 .lix-sketch-theme .bn-editor,
 .lix-sketch-theme [contenteditable="true"] {
   cursor: text;
 }
-
-/* Drag handles, side menu, toolbar — keep pointer cursor */
 .lix-sketch-theme .bn-side-menu,
 .lix-sketch-theme .bn-side-menu *,
 .lix-sketch-theme .mantine-ActionIcon-root,
@@ -304,14 +369,14 @@ body.canvas-mode.theme-dark .lix-sketch-theme .mantine-Button-root:hover {
   cursor: pointer;
 }
 
-/* Scrollbar — match canvas */
+/* Scrollbar — pick up the divider token so it adapts. */
 .lix-editor-host::-webkit-scrollbar {
   width: 8px;
 }
 .lix-editor-host::-webkit-scrollbar-thumb {
-  background: #3a3a50;
+  background: var(--divider);
   border-radius: 4px;
 }
 .lix-editor-host::-webkit-scrollbar-thumb:hover {
-  background: #5B57D1;
+  background: var(--border-hover);
 }


### PR DESCRIPTION
## What this does
Rewrites \`src/components/docs/docs-theme.css\` so the BlockNote editor inside the canvas's docs pane renders block elements (headings, prose, inline code, code blocks, dividers, menus, hover) identically to the blogs.elixpo editor — in both light and dark mode.

## Why
Sketch's prior docs theme overrode BlockNote's chrome but used hardcoded near-black backgrounds and a lixFont everywhere, so the same scene looks one way in blogs.elixpo's editor and quite different in sketch.elixpo's split pane. The user asked for them to match.

## Changes
- Mirrored the blogs token set under \`body.canvas-mode\` (light defaults) and \`body.canvas-mode.theme-dark\` (overrides): \`--bg-app\`, \`--bg-surface\`, \`--bg-elevated\`, \`--bg-hover\`, \`--border-default\`, \`--text-primary\`, \`--text-secondary\`, \`--text-muted\`, \`--text-faint\`, \`--accent\`, \`--code-bg\`, \`--code-text\`, \`--code-lang-bg\`, \`--code-lang-text\`, \`--divider\`. Values copied verbatim from \`blogs.elixpo/app/globals.css\`.
- Rerouted BlockNote's own \`--bn-colors-*\` variables to point at the mirrored blogs tokens so the editor chrome adopts the same palette without separate light/dark rules.
- Ported the per-block styles from \`blogs.elixpo/src/styles/editor/\` (base.css + blocks.css) with \`.blog-editor-wrapper\` rewritten to \`.lix-sketch-theme\`:
  - Headings (h1 30px / h2 24px / h3 20px, Source Serif 4, weights 700/650/600).
  - Editor body — Source Serif 4 1em / 1.75 line-height.
  - Inline code — purple chip (#7c3aed light / #c4b5fd dark) with 0.82em sizing.
  - Code blocks — \`var(--code-bg)\` surface with \`var(--border-default)\` border, lixCode font, language selector dropdown styled.
  - Divider — \`var(--border-default)\` 1px line.
  - Mantine slash menu / popovers / suggestion menu — \`var(--bg-elevated)\` surface with text + border tokens.
- Kept sketch-specific layout fixes: \`.lix-editor-wrapper\` padding-left for the side menu, vertical \`bn-side-menu\` stacking, scrollbar styling, cursor on chrome.
- Added \`@import\` for Source Serif 4 from Google Fonts (display=swap, same URL as blogs).

## Verification
- Side-by-side: open a docs pane in canvas vs the blogs editor page; the same content should produce identical heading sizes, inline-code chips, code-block surfaces, and dividers in both themes.

---
Refs #38