### PR TITLE
[ELIXPO] Text tool: bordered swatch + selection lifecycle + light textbox outline (#48 A+B+C)

### DIFF
--- a/packages/lixsketch/src/tools/textTool.js
+++ b/packages/lixsketch/src/tools/textTool.js
@@ -127,13 +127,17 @@ function addText(event) {
     textElement.setAttribute("cursor", "default");
     textElement.setAttribute("white-space", "pre");
     textElement.setAttribute("dominant-baseline", "hanging");
-    // Issue #34 bug #5b: SVG <text> only fires pointer events on the
-    // painted glyphs by default — so a click between letters or in the
-    // padding around the text never bubbles to the <g> and the selection
-    // tool can't pick the shape up. `bounding-box` extends the hit area
-    // to the entire bounding box (SVG 2; supported in Chromium/WebKit/
-    // Firefox), which is what every other shape tool relies on.
-    textElement.setAttribute("pointer-events", "bounding-box");
+    // Issue #48 bugs #1 / #3: reverted the previous `bounding-box` hit
+    // area (introduced for #34 #5b) — extending the text's hit zone to
+    // its full bbox meant the negative space between glyphs and around
+    // the text was stealing clicks from shapes drawn ON TOP of the text
+    // (drag a rect over text → text intercepts; select text then click a
+    // different shape elsewhere → click lands in text's invisible bbox
+    // and the text stays selected). Default `painted` only fires on
+    // glyph pixels, which restores the expected pass-through. Trade-off:
+    // empty-padding clicks no longer select the text — the user has to
+    // click on the letters.
+    textElement.setAttribute("pointer-events", "painted");
     textElement.textContent = "";
 
     gElement.setAttribute("data-x", x);

--- a/packages/lixsketch/src/tools/textTool.js
+++ b/packages/lixsketch/src/tools/textTool.js
@@ -260,11 +260,16 @@ function makeTextEditable(textElement, groupElement) {
     input.style.lineHeight = "1.2em";
     input.style.textAlign = currentAnchor === "middle" ? "center" : currentAnchor === "end" ? "right" : "left";
     input.style.backgroundColor = "transparent";
-    // Issue #34 bug #5a: dashed creation outline that grows with the
-    // text — same visual cue the frame tool uses while drawing. Inset
-    // padding-box border so the dashes follow the textarea size as the
-    // user types instead of clipping behind the glyphs.
-    input.style.border = "1px dashed rgba(255,255,255,0.55)";
+    // Issue #34 bug #5a + #48 bug #2: dashed creation outline that grows
+    // with the text. Originally `rgba(255,255,255,0.55)` — invisible on
+    // the new light canvas. Read the active theme so the dashes stay
+    // visible in both modes.
+    const _isDark = typeof document !== 'undefined'
+        && document.body
+        && document.body.classList.contains('theme-dark');
+    input.style.border = _isDark
+        ? "1px dashed rgba(255,255,255,0.55)"
+        : "1px dashed rgba(40,40,60,0.45)";
     input.style.borderRadius = "3px";
     input.style.outline = "none";
     document.body.appendChild(input);

--- a/src/components/sidebars/ArrowSidebar.jsx
+++ b/src/components/sidebars/ArrowSidebar.jsx
@@ -23,7 +23,7 @@ function ColorGrid({ colors, selected, onSelect }) {
     <div className="grid grid-cols-4 gap-1.5">
       {colors.map((c) => (
         <button key={c} onClick={() => onSelect(c)}
-          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-white/[0.08] hover:border-white/20'}`}
+          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-border-light hover:border-text-dim'}`}
           style={{ backgroundColor: c }}
         />
       ))}
@@ -98,7 +98,7 @@ export default function ArrowSidebar() {
       <Divider />
 
       <ToolbarButton tooltip={t('sidebar.strokeColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: strokeColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: strokeColor }} />}
       >
         <p className="text-xs text-text-secondary uppercase tracking-wider mb-2">{t('sidebar.sectionHeader.stroke')}</p>
         <ColorGrid colors={STROKE_COLORS} selected={strokeColor} onSelect={updateStroke} />

--- a/src/components/sidebars/CircleSidebar.jsx
+++ b/src/components/sidebars/CircleSidebar.jsx
@@ -26,7 +26,7 @@ function ColorGrid({ colors, selected, onSelect }) {
             key={c}
             onClick={() => onSelect(c)}
             className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${
-              selected === c ? 'border-accent-blue scale-110' : 'border-white/[0.08] hover:border-white/20'
+              selected === c ? 'border-accent-blue scale-110' : 'border-border-light hover:border-text-dim'
             }`}
             style={!isTrans ? { backgroundColor: c } : undefined}
           >
@@ -62,7 +62,7 @@ export default function CircleSidebar() {
     <ShapeSidebar visible={activeTool === TOOLS.CIRCLE || selectedShapeSidebar === 'circle'}>
       <ToolbarButton
         tooltip={t('sidebar.strokeColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: strokeColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: strokeColor }} />}
       >
         <p className="text-xs text-text-muted uppercase tracking-wider mb-2">{t('sidebar.sectionHeader.stroke')}</p>
         <ColorGrid colors={STROKE_COLORS} selected={strokeColor} onSelect={updateStroke} />
@@ -73,7 +73,7 @@ export default function CircleSidebar() {
       <ToolbarButton
         tooltip={t('sidebar.fillColor')}
         preview={
-          <span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: bgColor === 'transparent' ? 'transparent' : bgColor }}>
+          <span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: bgColor === 'transparent' ? 'transparent' : bgColor }}>
             {bgColor === 'transparent' && <svg className="w-full h-full text-text-dim" viewBox="0 0 16 16"><line x1="2" y1="14" x2="14" y2="2" stroke="currentColor" strokeWidth="1.5" /></svg>}
           </span>
         }

--- a/src/components/sidebars/LineSidebar.jsx
+++ b/src/components/sidebars/LineSidebar.jsx
@@ -12,7 +12,7 @@ function ColorGrid({ colors, selected, onSelect }) {
     <div className="grid grid-cols-4 gap-1.5">
       {colors.map((c) => (
         <button key={c} onClick={() => onSelect(c)}
-          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-white/[0.08] hover:border-white/20'}`}
+          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-border-light hover:border-text-dim'}`}
           style={{ backgroundColor: c }}
         />
       ))}
@@ -39,7 +39,7 @@ export default function LineSidebar() {
   return (
     <ShapeSidebar visible={activeTool === TOOLS.LINE || selectedShapeSidebar === 'line'}>
       <ToolbarButton tooltip={t('sidebar.strokeColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: strokeColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: strokeColor }} />}
       >
         <p className="text-xs text-text-muted uppercase tracking-wider mb-2">{t('sidebar.sectionHeader.stroke')}</p>
         <ColorGrid colors={STROKE_COLORS} selected={strokeColor} onSelect={updateStroke} />

--- a/src/components/sidebars/PaintbrushSidebar.jsx
+++ b/src/components/sidebars/PaintbrushSidebar.jsx
@@ -15,7 +15,7 @@ function ColorGrid({ colors, selected, onSelect }) {
     <div className="grid grid-cols-4 gap-1.5">
       {colors.map((c) => (
         <button key={c} onClick={() => onSelect(c)}
-          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-white/[0.08] hover:border-white/20'}`}
+          className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${selected === c ? 'border-[#5B57D1] scale-110' : 'border-border-light hover:border-text-dim'}`}
           style={{ backgroundColor: c }}
         />
       ))}
@@ -43,7 +43,7 @@ export default function PaintbrushSidebar() {
   return (
     <ShapeSidebar visible={activeTool === TOOLS.FREEHAND || selectedShapeSidebar === 'paintbrush'}>
       <ToolbarButton tooltip={t('sidebar.strokeColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: strokeColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: strokeColor }} />}
       >
         <p className="text-xs text-text-muted uppercase tracking-wider mb-2">{t('sidebar.sectionHeader.stroke')}</p>
         <ColorGrid colors={STROKE_COLORS} selected={strokeColor} onSelect={updateStroke} />

--- a/src/components/sidebars/RectangleSidebar.jsx
+++ b/src/components/sidebars/RectangleSidebar.jsx
@@ -26,7 +26,7 @@ function ColorGrid({ colors, selected, onSelect }) {
             key={c}
             onClick={() => onSelect(c)}
             className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${
-              selected === c ? 'border-[#5B57D1] scale-110' : 'border-white/[0.08] hover:border-white/20'
+              selected === c ? 'border-[#5B57D1] scale-110' : 'border-border-light hover:border-text-dim'
             }`}
             style={!isTrans ? { backgroundColor: c } : undefined}
           >
@@ -68,7 +68,7 @@ export default function RectangleSidebar() {
       {/* Stroke color */}
       <ToolbarButton
         tooltip={t('sidebar.strokeColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: strokeColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: strokeColor }} />}
       >
         <p className="text-xs text-text-muted uppercase tracking-wider mb-2">{t('sidebar.sectionHeader.stroke')}</p>
         <ColorGrid colors={STROKE_COLORS} selected={strokeColor} onSelect={updateStroke} />
@@ -80,7 +80,7 @@ export default function RectangleSidebar() {
       <ToolbarButton
         tooltip={t('sidebar.fillColor')}
         preview={
-          <span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: bgColor === 'transparent' ? 'transparent' : bgColor }}>
+          <span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: bgColor === 'transparent' ? 'transparent' : bgColor }}>
             {bgColor === 'transparent' && (
               <svg className="w-full h-full text-text-dim" viewBox="0 0 16 16"><line x1="2" y1="14" x2="14" y2="2" stroke="currentColor" strokeWidth="1.5" /></svg>
             )}

--- a/src/components/sidebars/TextSidebar.jsx
+++ b/src/components/sidebars/TextSidebar.jsx
@@ -81,13 +81,13 @@ export default function TextSidebar() {
     <ShapeSidebar visible={visible}>
       {/* Color */}
       <ToolbarButton tooltip={t('sidebar.textColor')}
-        preview={<span className="w-4 h-4 rounded-md border border-white/20" style={{ backgroundColor: textColor }} />}
+        preview={<span className="w-4 h-4 rounded-md border border-border-light" style={{ backgroundColor: textColor }} />}
       >
         <p className="text-xs text-text-muted uppercase tracking-wider mb-2">{t('sidebar.color')}</p>
         <div className="grid grid-cols-4 gap-1.5">
           {TEXT_COLORS.map((c) => (
             <button key={c} onClick={() => updateColor(c)}
-              className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${textColor === c ? 'border-[#5B57D1] scale-110' : 'border-white/[0.08] hover:border-white/20'}`}
+              className={`w-7 h-7 rounded-md border-[1.5px] transition-all duration-100 ${textColor === c ? 'border-[#5B57D1] scale-110' : 'border-border-light hover:border-text-dim'}`}
               style={{ backgroundColor: c }}
             />
           ))}


### PR DESCRIPTION
## What this does
Three coordinated text-tool fixes from issue #48.
1. **Stroke / colour swatch in the bottom shape toolbar gets a visible border.** The hardcoded \`border-white/20\` was nearly invisible on the new light surface — swapped for \`border-border-light\` so the swatch reads as a chip in both themes. Same fix on the unselected colour-grid cells.
2. **Text shape no longer steals clicks from shapes on top.** SVG \`<text>\` had \`pointer-events: bounding-box\` (added under #34 #5b to widen the click target between letters). That bbox extended into the text's empty padding, so dragging a rectangle over a text intercepted into a text selection, and clicking a "different shape" elsewhere that happened to land in text's invisible bbox kept the text selected. Reverted to \`pointer-events: painted\` — glyph-pixel clicks only. Trade-off: empty-padding clicks no longer select the text, but the active drag isn't hijacked either.
3. **Textbox creation outline visible in light mode.** The dashed border on the floating \`<textarea>\` editor was \`rgba(255,255,255,0.55)\` — invisible on the new warm off-white canvas. Now picks between the white shade (dark theme) and a dark slate \`rgba(40,40,60,0.45)\` (light theme) based on \`body.classList.contains('theme-dark')\`.

## Why
Issue #48, phases A + B + C. The earlier #34 / #35 work used hardcoded white / bounding-box defaults that read fine on the old dark canvas but break under the light-mode rework.

## Changes
- \`src/components/sidebars/{Arrow,Circle,Line,Paintbrush,Rectangle,Text}Sidebar.jsx\`: \`border border-white/20\` → \`border border-border-light\` on the colour preview swatches; color-grid unselected cells \`border-white/[0.08] hover:border-white/20\` → \`border-border-light hover:border-text-dim\`.
- \`packages/lixsketch/src/tools/textTool.js\`:
  - \`addText\`: \`pointer-events="bounding-box"\` → \`pointer-events="painted"\` with comment explaining the trade-off.
  - \`makeTextEditable\`: dashed border now branches on \`document.body.classList.contains('theme-dark')\` — dark theme keeps the white shade, light theme uses \`rgba(40,40,60,0.45)\`.

## Verification
- Bug 1 (drag-shape-onto-text): dragging a rect over a text shape no longer interrupts into a text-select.
- Bug 2 (light textbox boundary): clicking with text tool on the light canvas now shows the dashed outline.
- Bug 3 (text stays selected on click-different-shape): clicking a rect after a text was selected releases the text — both via the dispatcher fall-through and because the text doesn't intercept clicks in its negative space.
- Bug 4 (stroke swatch border): the colour preview chip in the bottom toolbar is visible in light mode.

Phase D (#5 — E / W width-only anchors on text) is still pending and will land in a follow-up PR.

---
Refs #48