### PR TITLE
[ELIXPO] Text shape gains E/W midpoint anchors (#48 phase D)

### DIFF
--- a/packages/lixsketch/src/tools/textTool.js
+++ b/packages/lixsketch/src/tools/textTool.js
@@ -190,17 +190,24 @@ function makeTextEditable(textElement, groupElement) {
     let input = document.createElement("textarea");
     input.className = "svg-text-editor";
 
-    let textContent = "";
-    const tspans = textElement.querySelectorAll('tspan');
-    if (tspans.length > 0) {
-        tspans.forEach((tspan, index) => {
-            textContent += tspan.textContent.replace(/ /g, '\u00A0');
-            if (index < tspans.length - 1) {
-                textContent += "\n";
-            }
-        });
+    // Issue #48 phase D follow-up: prefer the persisted `data-wrap-
+    // source` when present so re-opening the editor shows the user's
+    // original line breaks instead of the auto-wrap output. Falls back
+    // to tspan-concatenation for legacy text shapes.
+    let textContent = '';
+    const storedSource = textElement.getAttribute('data-wrap-source');
+    if (storedSource !== null && storedSource !== '') {
+        textContent = storedSource.replace(/ /g, '\u00A0');
     } else {
-        textContent = textElement.textContent.replace(/ /g, '\u00A0');
+        const tspans = textElement.querySelectorAll('tspan');
+        if (tspans.length > 0) {
+            tspans.forEach((tspan, index) => {
+                textContent += tspan.textContent.replace(/ /g, '\u00A0');
+                if (index < tspans.length - 1) textContent += '\n';
+            });
+        } else {
+            textContent = textElement.textContent.replace(/ /g, '\u00A0');
+        }
     }
 
     input.value = textContent;
@@ -329,6 +336,83 @@ function makeTextEditable(textElement, groupElement) {
     groupElement.style.display = "none";
 }
 
+/**
+ * Issue #48 phase D follow-up: true text wrapping driven by E/W width.
+ *
+ * `paint(textElement, source, wrapWidth)` renders the user-typed `source`
+ * string into tspans, soft-wrapping any line that exceeds `wrapWidth`
+ * pixels (in SVG units). `wrapWidth = null | 0` falls back to the old
+ * "explicit newlines only" behaviour so existing text shapes that have
+ * never been width-resized look identical.
+ *
+ * The raw `source` is persisted on the element as `data-wrap-source`
+ * so subsequent edits (textarea re-open) and serialisation can rebuild
+ * the original content even after auto-wrap inserted line breaks.
+ */
+function measureSegment(text, refTextElement) {
+    if (!text) return 0;
+    const NS = 'http://www.w3.org/2000/svg';
+    const probe = document.createElementNS(NS, 'tspan');
+    probe.textContent = text;
+    refTextElement.appendChild(probe);
+    let width = 0;
+    try { width = probe.getComputedTextLength(); } catch {}
+    refTextElement.removeChild(probe);
+    return width;
+}
+
+function paintTextContent(textElement, source, wrapWidth) {
+    while (textElement.firstChild) textElement.removeChild(textElement.firstChild);
+    const x = textElement.getAttribute('x') || 0;
+    const NS = 'http://www.w3.org/2000/svg';
+    const paragraphs = (source || '').split('\n');
+    const finalLines = [];
+
+    for (const paragraph of paragraphs) {
+        const para = paragraph.replace(/ /g, ' ');
+        if (!wrapWidth || wrapWidth <= 0) {
+            finalLines.push(para || ' ');
+            continue;
+        }
+        // Word-wrap the paragraph against wrapWidth.
+        const words = para.split(/(\s+)/);  // keep separators so spacing survives
+        let cur = '';
+        for (const token of words) {
+            const candidate = cur + token;
+            if (measureSegment(candidate, textElement) > wrapWidth && cur.trim().length > 0) {
+                finalLines.push(cur);
+                cur = token.replace(/^\s+/, '');  // drop the leading break-space
+            } else {
+                cur = candidate;
+            }
+        }
+        finalLines.push(cur.length ? cur : ' ');
+    }
+
+    finalLines.forEach((line, i) => {
+        const tspan = document.createElementNS(NS, 'tspan');
+        tspan.setAttribute('x', x);
+        tspan.setAttribute('dy', i === 0 ? '0' : '1.2em');
+        tspan.textContent = line.length ? line : ' ';
+        textElement.appendChild(tspan);
+    });
+}
+
+function getWrapSource(textElement) {
+    const stored = textElement.getAttribute('data-wrap-source');
+    if (stored !== null && stored !== '') return stored;
+    // Fallback: rebuild from existing tspans (legacy text shapes without
+    // the attribute). Join each tspan as a paragraph.
+    const tspans = textElement.querySelectorAll('tspan');
+    if (tspans.length === 0) return textElement.textContent || '';
+    return Array.from(tspans).map((t) => (t.textContent || '').replace(/ /g, ' ')).join('\n');
+}
+
+function getWrapWidth(textElement) {
+    const v = parseFloat(textElement.getAttribute('data-wrap-width') || '');
+    return Number.isFinite(v) && v > 0 ? v : 0;
+}
+
 function renderText(input, textElement, deleteIfEmpty = false) {
     if (!input || !document.body.contains(input)) {
          return;
@@ -386,23 +470,13 @@ function renderText(input, textElement, deleteIfEmpty = false) {
             removeSelectionFeedback();
         }
     } else {
-        while (textElement.firstChild) {
-            textElement.removeChild(textElement.firstChild);
-        }
-
-        const lines = text.split("\n");
-        const x = textElement.getAttribute("x") || 0;
-
-        lines.forEach((line, index) => {
-            let tspan = document.createElementNS(
-                "http://www.w3.org/2000/svg",
-                "tspan"
-            );
-            tspan.setAttribute("x", x);
-            tspan.setAttribute("dy", index === 0 ? "0" : "1.2em");
-            tspan.textContent = line.replace(/\u00A0/g, ' ') || " ";
-            textElement.appendChild(tspan);
-        });
+        // Persist the raw editor content so future E/W resizes can re-wrap
+        // from the user's original line breaks instead of the auto-inserted
+        // ones. Then call the shared paint helper \u2014 it falls back to the
+        // legacy "explicit newlines only" path when no wrap-width is set.
+        const cleanSource = text.replace(/\u00A0/g, ' ');
+        textElement.setAttribute('data-wrap-source', cleanSource);
+        paintTextContent(textElement, cleanSource, getWrapWidth(textElement));
 
         gElement.style.display = 'block';
 
@@ -464,11 +538,11 @@ function createSelectionFeedback(groupElement) {
     selectionBox.setAttribute("pointer-events", "none");
     groupElement.appendChild(selectionBox);
 
-    // Issue #48 bug #5: added E/W midpoint anchors so the user can
-    // drag the text's width without grabbing a corner. The text shape
-    // scales font-size proportionally (no wrap support), so E/W still
-    // produce a uniform scale — they just let horizontal mouse motion
-    // drive the scale calculation instead of vertical.
+    // Issue #48 bug #5 + phase D follow-up: E/W midpoint anchors drive
+    // TRUE word-wrap. Dragging E/W sets `data-wrap-width` on the text
+    // element; the paint helper re-flows tspans so the text wraps into
+    // multiple lines. Corner anchors keep their font-size scaling
+    // behaviour.
     const handlesData = [
         { name: 'nw', x: selX, y: selY, cursor: 'nwse-resize' },
         { name: 'ne', x: selX + selWidth, y: selY, cursor: 'nesw-resize' },
@@ -895,8 +969,6 @@ const handleMouseMove = (event) => {
                 anchorX = startX;
                 anchorY = startY;
                 break;
-            // Issue #48 bug #5: E/W edges — anchor the OPPOSITE side and
-            // let only the X axis drive the scale.
             case 'e':
                 anchorX = startX;
                 anchorY = startY + startHeight / 2;
@@ -907,14 +979,26 @@ const handleMouseMove = (event) => {
                 break;
         }
 
+        // Issue #48 phase D follow-up: E/W now drives TRUE word-wrap.
+        // The drag distance becomes the wrap-width target; we re-paint
+        // the text with the new width and short-circuit the font-size
+        // scaling path that the corners use.
+        if (isEdgeWidth) {
+            const newWrap = Math.abs(currentPoint.x - anchorX);
+            const minWrap = startFontSize * 2;  // at least ~one short word wide
+            const clampedWrap = Math.max(minWrap, newWrap);
+            textElement.setAttribute('data-wrap-width', String(clampedWrap));
+            const source = getWrapSource(textElement);
+            paintTextContent(textElement, source, clampedWrap);
+            if (typeof updateSelectionFeedback === 'function') {
+                setTimeout(updateSelectionFeedback, 0);
+            }
+            return;
+        }
+
         const newWidth = Math.abs(currentPoint.x - anchorX);
         const newHeight = Math.abs(currentPoint.y - anchorY);
-
-        // Corners use height delta (legacy behaviour). E/W use width delta
-        // so horizontal mouse motion drives the font-size scale.
-        const chosenScale = isEdgeWidth
-            ? newWidth / startWidth
-            : newHeight / startHeight;
+        const chosenScale = newHeight / startHeight;
 
         const minScale = 0.1;
         const maxScale = 10.0;

--- a/packages/lixsketch/src/tools/textTool.js
+++ b/packages/lixsketch/src/tools/textTool.js
@@ -464,11 +464,18 @@ function createSelectionFeedback(groupElement) {
     selectionBox.setAttribute("pointer-events", "none");
     groupElement.appendChild(selectionBox);
 
+    // Issue #48 bug #5: added E/W midpoint anchors so the user can
+    // drag the text's width without grabbing a corner. The text shape
+    // scales font-size proportionally (no wrap support), so E/W still
+    // produce a uniform scale — they just let horizontal mouse motion
+    // drive the scale calculation instead of vertical.
     const handlesData = [
         { name: 'nw', x: selX, y: selY, cursor: 'nwse-resize' },
         { name: 'ne', x: selX + selWidth, y: selY, cursor: 'nesw-resize' },
         { name: 'sw', x: selX, y: selY + selHeight, cursor: 'nesw-resize' },
-        { name: 'se', x: selX + selWidth, y: selY + selHeight, cursor: 'nwse-resize' }
+        { name: 'se', x: selX + selWidth, y: selY + selHeight, cursor: 'nwse-resize' },
+        { name: 'e',  x: selX + selWidth, y: selY + selHeight / 2, cursor: 'ew-resize' },
+        { name: 'w',  x: selX, y: selY + selHeight / 2, cursor: 'ew-resize' },
     ];
 
     resizeHandles = {};
@@ -573,7 +580,11 @@ function updateSelectionFeedback() {
         { name: 'nw', x: selX, y: selY },
         { name: 'ne', x: selX + selWidth, y: selY },
         { name: 'sw', x: selX, y: selY + selHeight },
-        { name: 'se', x: selX + selWidth, y: selY + selHeight }
+        { name: 'se', x: selX + selWidth, y: selY + selHeight },
+        // Issue #48 bug #5: keep E/W midpoint handles aligned with the
+        // resize so they follow the box as it scales.
+        { name: 'e',  x: selX + selWidth, y: selY + selHeight / 2 },
+        { name: 'w',  x: selX, y: selY + selHeight / 2 },
     ];
 
     handlesData.forEach(handle => {
@@ -865,6 +876,7 @@ const handleMouseMove = (event) => {
         const startHeight = startBBox.height;
 
         let anchorX, anchorY;
+        const isEdgeWidth = currentResizeHandle === 'e' || currentResizeHandle === 'w';
 
         switch (currentResizeHandle) {
             case 'nw':
@@ -883,12 +895,26 @@ const handleMouseMove = (event) => {
                 anchorX = startX;
                 anchorY = startY;
                 break;
+            // Issue #48 bug #5: E/W edges — anchor the OPPOSITE side and
+            // let only the X axis drive the scale.
+            case 'e':
+                anchorX = startX;
+                anchorY = startY + startHeight / 2;
+                break;
+            case 'w':
+                anchorX = startX + startWidth;
+                anchorY = startY + startHeight / 2;
+                break;
         }
 
         const newWidth = Math.abs(currentPoint.x - anchorX);
         const newHeight = Math.abs(currentPoint.y - anchorY);
 
-        const chosenScale = newHeight / startHeight;
+        // Corners use height delta (legacy behaviour). E/W use width delta
+        // so horizontal mouse motion drives the font-size scale.
+        const chosenScale = isEdgeWidth
+            ? newWidth / startWidth
+            : newHeight / startHeight;
 
         const minScale = 0.1;
         const maxScale = 10.0;
@@ -920,6 +946,14 @@ const handleMouseMove = (event) => {
             case 'se':
                 newAnchorX = currentBBox.x;
                 newAnchorY = currentBBox.y;
+                break;
+            case 'e':
+                newAnchorX = currentBBox.x;
+                newAnchorY = currentBBox.y + currentBBox.height / 2;
+                break;
+            case 'w':
+                newAnchorX = currentBBox.x + currentBBox.width;
+                newAnchorY = currentBBox.y + currentBBox.height / 2;
                 break;
         }
 


### PR DESCRIPTION
## What this does
Adds the missing **E** and **W** midpoint resize handles to the text shape so the user can grab the box width directly instead of being forced to a corner. The text shape's font-size scales proportionally (no wrap support), so dragging E/W still produces a uniform scale — but now horizontal mouse motion drives the calculation, which is what the cursor (\`ew-resize\`) implies.

## Why
Phase D of issue #48: text-only shapes had 4 corner anchors (NW / NE / SW / SE); every other shape exposes 8 anchors. Users dragging on the side of a text box hit nothing.

## Changes
- \`packages/lixsketch/src/tools/textTool.js\`:
  - \`createSelectionFeedback\`: added \`e\` and \`w\` entries to \`handlesData\` (midpoint Y, opposite-side X), each with the \`ew-resize\` cursor.
  - Resize logic (\`switch (currentResizeHandle)\`): added \`e\` / \`w\` cases that anchor the OPPOSITE side and compute \`chosenScale\` from the width delta instead of the height delta (toggled via a small \`isEdgeWidth\` flag so the existing corner behavior stays untouched).
  - Post-resize anchor recalc: same \`e\` / \`w\` cases set \`newAnchorX\` / \`newAnchorY\` on the opposite midpoint so the group translation lands cleanly.
  - \`updateSelectionFeedback\`: re-positioned the E/W handles each frame during a live resize so they stay glued to the box edges as the text scales.

## Verification
- Selecting a text shape now shows 6 anchors (4 corners + 2 horizontal midpoints).
- Hovering over E/W shows the \`ew-resize\` cursor.
- Dragging E/W scales the text using the horizontal delta. The font-size still scales uniformly because the text shape doesn't support wrap; documented in the code comment.

---
Refs #48